### PR TITLE
Endpoint Eliminar Novedades (OT229-48)

### DIFF
--- a/src/main/java/com/alkemy/ong/controllers/NewsController.java
+++ b/src/main/java/com/alkemy/ong/controllers/NewsController.java
@@ -1,18 +1,22 @@
 package com.alkemy.ong.controllers;
 
+import com.alkemy.ong.dto.DeleteEntityResponse;
 import com.alkemy.ong.dto.NewsDTO;
 import com.alkemy.ong.services.CloudStorageService;
 import com.alkemy.ong.services.NewsService;
+import com.alkemy.ong.utility.GlobalConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
+import java.io.IOException;
 
 @RestController
-@RequestMapping("news")
+@RequestMapping(GlobalConstants.Endpoints.NEWS)
 public class NewsController {
 
   @Autowired
@@ -40,4 +44,17 @@ public class NewsController {
 
       return ResponseEntity.status(HttpStatus.OK).body(newsDTO);
   }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<?> deleteNews(@PathVariable String id) {
+    try {
+      NewsDTO newsDTO = this.newsService.deleteNews(id);
+      return ResponseEntity.ok(new DeleteEntityResponse("News successfully deleted.", newsDTO));
+    } catch (EntityNotFoundException e) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    } catch (IOException cloudStorageServiceProblemException) {
+      return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("There was a problem trying do delete the associated images. Please try again later.");
+    }
+  }
+
 }

--- a/src/main/java/com/alkemy/ong/dto/DeleteEntityResponse.java
+++ b/src/main/java/com/alkemy/ong/dto/DeleteEntityResponse.java
@@ -1,0 +1,22 @@
+package com.alkemy.ong.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Object used as the response body for all entity deleting endpoints.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Accessors(chain = true)
+public class DeleteEntityResponse {
+
+    private String message;
+    private Object deleted_object;
+
+}

--- a/src/main/java/com/alkemy/ong/entities/News.java
+++ b/src/main/java/com/alkemy/ong/entities/News.java
@@ -33,7 +33,6 @@ public class News {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
     private String image;
 
     @CreationTimestamp

--- a/src/main/java/com/alkemy/ong/entities/News.java
+++ b/src/main/java/com/alkemy/ong/entities/News.java
@@ -18,8 +18,8 @@ import java.util.Date;
 @NoArgsConstructor
 @Getter
 @Setter
-@SQLDelete(sql = "UPDATE activity SET soft_deleted = true WHERE id = ?")
-@Where(clause = "soft_deleted = false")
+@SQLDelete(sql = "UPDATE news SET soft_delete = true WHERE id = ?")
+@Where(clause = "soft_delete = false")
 public class News {
 
     @Id
@@ -37,7 +37,7 @@ public class News {
 
     @CreationTimestamp
     private Date timestamp;
-    @Column(name = "soft_deleted")
+    @Column(name = "soft_delete")
     private Boolean softDelete=Boolean.FALSE;
 
     @ManyToOne()

--- a/src/main/java/com/alkemy/ong/repositories/NewsRepository.java
+++ b/src/main/java/com/alkemy/ong/repositories/NewsRepository.java
@@ -4,6 +4,11 @@ import com.alkemy.ong.entities.News;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface NewsRepository extends JpaRepository<News,String> {
+
+    Optional<News> findById(String id);
+
 }

--- a/src/main/java/com/alkemy/ong/services/NewsService.java
+++ b/src/main/java/com/alkemy/ong/services/NewsService.java
@@ -1,12 +1,25 @@
 package com.alkemy.ong.services;
 
 import com.alkemy.ong.dto.NewsDTO;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.persistence.EntityNotFoundException;
 import java.io.IOException;
 
 public interface NewsService {
   NewsDTO save (MultipartFile file, NewsDTO news) throws IOException;
 
   NewsDTO findById(String id);
+
+  /**
+   * Deletes a news entry from the persistent storage.
+   *
+   * @param id  the id of the News object to be deleted.
+   * @return  the DTO of the deleted object.
+   * @throws EntityNotFoundException  if an entity with the provided id can't be found.
+   * @throws IOException  if there was a problem with the cloud storage service while attempting to delete the associated image.
+   */
+  NewsDTO deleteNews(String id) throws EntityNotFoundException, IOException;
+
 }

--- a/src/main/java/com/alkemy/ong/services/impl/NewsServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/NewsServiceImpl.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.services.impl;
 
 import com.alkemy.ong.dto.NewsDTO;
 import com.alkemy.ong.entities.News;
+import com.alkemy.ong.exception.AmazonS3Exception;
 import com.alkemy.ong.mappers.NewsMapper;
 import com.alkemy.ong.repositories.NewsRepository;
 import com.alkemy.ong.services.CloudStorageService;
@@ -11,7 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -43,6 +46,38 @@ public class NewsServiceImpl implements NewsService {
       throw new RuntimeException("Not found news");
     }
     return newsMapper.newsEntity2DTO(news.get());
+  }
+
+  @Transactional
+  @Override
+  public NewsDTO deleteNews(String id) throws EntityNotFoundException, IOException {
+    News newsToDelete = this.newsRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("News with the provided id not found."));
+    this.deleteNewsImageFromCloudStorage(newsToDelete);
+    NewsDTO newsDTO = this.newsMapper.newsEntity2DTO(newsToDelete);
+    this.newsRepository.delete(newsToDelete);
+    return newsDTO;
+  }
+
+  /**
+   * Deletes the image referenced by a News entity from the cloud storage.
+   *
+   * @param news the owner of the image.
+   * @throws IOException  if there was a problem with the cloud storage client.
+   */
+  private void deleteNewsImageFromCloudStorage(News news) throws IOException {
+    if (news.getImage() != null && !news.getImage().equals("")) {
+      try {
+        this.cloudStorageService.deleteFileFromS3Bucket(news.getImage());
+      } catch (IOException e) {
+        // All exceptions thrown from deleteFileFromS3Bucket() inherit from IOException, FileNotFoundException being one.
+        // In the case where it was FileNotFoundException, meaning there was no file stored in the S3 service with the
+        // provided url, then I don't need to do anything, hence it's excluded from the "if" and it's not thrown again.
+        if (!(e instanceof FileNotFoundException)) {
+          throw e;
+        }
+      }
+    }
   }
 
 }

--- a/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
+++ b/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
@@ -14,6 +14,7 @@ public abstract class GlobalConstants {
         public static final String USER = "/users/";
         public static final String CATEGORIES = "/categories";
         public static final String CLOUD_STORAGE = "/cloud-storage";
+        public static final String NEWS = "/news";
 
     }
 


### PR DESCRIPTION
Se crea el endpoint para eliminar una News por id.

- La imagen de la News, si existe, se borra de S3.
- La entidad de borra con soft delete.
- Se retorna una respuesta con un mensaje y el DTO de la entidad eliminada.