### PR TITLE
Endpoint Actualización Novedades OT229-47

### DIFF
--- a/src/main/java/com/alkemy/ong/controllers/NewsController.java
+++ b/src/main/java/com/alkemy/ong/controllers/NewsController.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.controllers;
 
 import com.alkemy.ong.dto.DeleteEntityResponse;
 import com.alkemy.ong.dto.NewsDTO;
+import com.alkemy.ong.exception.AmazonS3Exception;
 import com.alkemy.ong.services.CloudStorageService;
 import com.alkemy.ong.services.NewsService;
 import com.alkemy.ong.utility.GlobalConstants;
@@ -54,6 +55,24 @@ public class NewsController {
       return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     } catch (IOException cloudStorageServiceProblemException) {
       return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("There was a problem trying do delete the associated images. Please try again later.");
+    }
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<?> updateNews(@RequestParam(value = "file", required = false) MultipartFile file,
+                                      @Valid @ModelAttribute NewsDTO updatedNews,
+                                      @PathVariable String id) {
+
+    try {
+      return ResponseEntity.ok(this.newsService.updateNews(id, file, updatedNews));
+    } catch (EntityNotFoundException e) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    } catch (AmazonS3Exception e) {
+      return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Image could not be saved. Try again later.");
+    } catch (IOException e) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Broken or invalid image");
     }
   }
 

--- a/src/main/java/com/alkemy/ong/dto/CategoryDTO.java
+++ b/src/main/java/com/alkemy/ong/dto/CategoryDTO.java
@@ -19,4 +19,7 @@ public class CategoryDTO {
     private String description;
 
     private String image;
+
+    private String id;
+
 }

--- a/src/main/java/com/alkemy/ong/mappers/CategoryMapper.java
+++ b/src/main/java/com/alkemy/ong/mappers/CategoryMapper.java
@@ -13,7 +13,7 @@ public class CategoryMapper {
         dto.setName(entity.getName());
         dto.setImage(entity.getImage());
         dto.setDescription(entity.getDescription());
-
+        dto.setId(entity.getId());
         return dto;
     }
 
@@ -22,7 +22,7 @@ public class CategoryMapper {
         entity.setDescription(dto.getDescription());
         entity.setImage(dto.getImage());
         entity.setName(dto.getName());
-
+        entity.setId(dto.getId());
         return entity;
     }
 

--- a/src/main/java/com/alkemy/ong/mappers/NewsMapper.java
+++ b/src/main/java/com/alkemy/ong/mappers/NewsMapper.java
@@ -30,4 +30,12 @@ public class NewsMapper {
     return dto;
   }
 
+  public void UpdateNewsInstance(News newsToBeUpdated, NewsDTO updatedNews) {
+    newsToBeUpdated.setId(updatedNews.getId());
+    newsToBeUpdated.setName(updatedNews.getName());
+    newsToBeUpdated.setContent(updatedNews.getContent());
+    newsToBeUpdated.setImage(updatedNews.getImage());
+    newsToBeUpdated.setCategory(this.categoryMapper.categoryDTO2Entity(updatedNews.getCategory()));
+  }
+
 }

--- a/src/main/java/com/alkemy/ong/services/CategoryEntityProvider.java
+++ b/src/main/java/com/alkemy/ong/services/CategoryEntityProvider.java
@@ -1,0 +1,23 @@
+package com.alkemy.ong.services;
+
+import com.alkemy.ong.entities.Category;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.Optional;
+
+/**
+ * Interface to be implemented by services which can retrieve and return a whole Entity from the persistance storage.
+ *
+ * Precaution: this interface should only be used by other services.
+ */
+public interface CategoryEntityProvider {
+
+    /**
+     * Retrieves a Category entity from the database.
+     *
+     * @param name    the Category name.
+     * @return  the Entity found wrapped in a Java Optional.
+     */
+    Optional<Category> getEntityByName(String name) throws EntityNotFoundException;
+
+}

--- a/src/main/java/com/alkemy/ong/services/NewsService.java
+++ b/src/main/java/com/alkemy/ong/services/NewsService.java
@@ -22,4 +22,19 @@ public interface NewsService {
    */
   NewsDTO deleteNews(String id) throws EntityNotFoundException, IOException;
 
+  /**
+   * Updates a News entry.
+   *
+   * @param id  the id of the News to be edited.
+   * @param image a new image for the News entity, or <code>null</code> if the image is not to be updated.
+   * @param updatedNews the DTO with the updated fields of the News. The Entity whole Entity is updated from these values,
+   *                    so every field must be present, not just the updated ones.
+   * @return  an dto with the info from the updated entity.
+   * @throws EntityNotFoundException  if an entity with the provided id can't be found.
+   * @throws IOException  if there was a problem with the file attached.
+   * @throws AmazonS3Exception  if there was a problem with the cloud storage service.
+   * @throws IllegalArgumentException if the News' Category to be updated is present but has an invalid name.
+   */
+  NewsDTO updateNews(String id, MultipartFile image, NewsDTO updatedNews) throws EntityNotFoundException, IOException, AmazonS3Exception, IllegalArgumentException;
+
 }

--- a/src/main/java/com/alkemy/ong/services/impl/CategoriesServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/CategoriesServiceImpl.java
@@ -5,15 +5,17 @@ import com.alkemy.ong.entities.Category;
 import com.alkemy.ong.mappers.CategoryMapper;
 import com.alkemy.ong.repositories.CategoryRepository;
 import com.alkemy.ong.services.CategoriesService;
+import com.alkemy.ong.services.CategoryEntityProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
-public class CategoriesServiceImpl implements CategoriesService {
+public class CategoriesServiceImpl implements CategoriesService, CategoryEntityProvider {
 
     @Autowired
     private CategoryMapper categoryMapper;
@@ -51,7 +53,7 @@ public class CategoriesServiceImpl implements CategoriesService {
         Optional<Category> entitySameName = categoryRepository.findByName(dto.getName());
         if (!entityFound.isPresent()) {
             throw new RuntimeException("Category with the provided ID not present");
-        } else if (entitySameName.isPresent() && entitySameName.get().getId() != entityFound.get().getId()) {
+        } else if (entitySameName.isPresent() && !entitySameName.get().getId().equals( entityFound.get().getId() )) {
             throw new RuntimeException("The name is already present over the system, please change it");
         }
 
@@ -73,4 +75,10 @@ public class CategoriesServiceImpl implements CategoriesService {
                 .collect(Collectors.toList());
 
     }
+
+    @Override
+    public Optional<Category> getEntityByName(String name) throws EntityNotFoundException {
+        return this.categoryRepository.findByName(name);
+    }
+
 }

--- a/src/main/java/com/alkemy/ong/services/impl/NewsServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/NewsServiceImpl.java
@@ -1,12 +1,17 @@
 package com.alkemy.ong.services.impl;
 
+import com.alkemy.ong.dto.CategoryDTO;
 import com.alkemy.ong.dto.NewsDTO;
+import com.alkemy.ong.entities.Category;
 import com.alkemy.ong.entities.News;
-import com.alkemy.ong.exception.AmazonS3Exception;
+import com.alkemy.ong.mappers.CategoryMapper;
 import com.alkemy.ong.mappers.NewsMapper;
 import com.alkemy.ong.repositories.NewsRepository;
+import com.alkemy.ong.services.CategoriesService;
+import com.alkemy.ong.services.CategoryEntityProvider;
 import com.alkemy.ong.services.CloudStorageService;
 import com.alkemy.ong.services.NewsService;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import javassist.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,6 +32,12 @@ public class NewsServiceImpl implements NewsService {
   private NewsRepository newsRepository;
   @Autowired
   private CloudStorageService cloudStorageService;
+  @Autowired
+  private CategoriesService categoriesService;
+  @Autowired
+  private CategoryEntityProvider categoryEntityProvider;
+  @Autowired
+  private CategoryMapper categoryMapper;
 
   @Transactional
   @Override
@@ -57,6 +68,54 @@ public class NewsServiceImpl implements NewsService {
     NewsDTO newsDTO = this.newsMapper.newsEntity2DTO(newsToDelete);
     this.newsRepository.delete(newsToDelete);
     return newsDTO;
+  }
+
+  @Transactional
+  @Override
+  public NewsDTO updateNews(String id, MultipartFile image, NewsDTO updatedNews) throws EntityNotFoundException, IOException, AmazonS3Exception, IllegalArgumentException {
+    News newsToUpdate = this.newsRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("News with the provided id not found."));
+    // If the News is not going to be update with a new image, then this attribute should have the current image url.
+    String updatedImageUrl = updatedNews.getImage();
+    if (image != null && !image.isEmpty()) {
+      updatedImageUrl = cloudStorageService.uploadFile(image);
+    }
+    updatedNews.setImage(updatedImageUrl);
+    this.newsMapper.UpdateNewsInstance(newsToUpdate, updatedNews);
+    this.updateNewsCategory(newsToUpdate, updatedNews.getCategory());
+    return this.newsMapper.newsEntity2DTO(newsToUpdate);
+  }
+
+  /**
+   * Obtains and sets the Category instance for a News entity that's going to be updated or created.
+   *
+   * To be updated or created, the News' category attribute must be an entity tracked by JPA so that the correct
+   * association can be established on save or update. This retrieves this Category instance if it exists, or it
+   * creates it and then returns it.
+   *
+   * @param updatedNews the News to be updated.
+   * @param categoryDTO the updated Category to be attached to the News.
+   * @throws IllegalArgumentException if the category must be created but doesn't have a proper name.
+   */
+  @Transactional
+  private void updateNewsCategory(News updatedNews, CategoryDTO categoryDTO) throws IllegalArgumentException {
+    Category category = null;
+    if (categoryDTO != null) {
+      if (categoryDTO.getName() == null || categoryDTO.getName().equals("")) {
+        throw new IllegalArgumentException("The Category provided for the News doesn't have a valid name.");
+      }
+      // If the category exists, retrieves it from the db.
+      category = this.categoryEntityProvider.getEntityByName(updatedNews.getCategory().getName())
+              // If it's a new category, it should be created.
+              .orElseGet(
+                      () -> {
+                        CategoryDTO newCategoryDTO = this.categoriesService.save(categoryDTO);
+                        // This is the return from this lambda function, not the method's return.
+                        return this.categoryEntityProvider.getEntityByName(newCategoryDTO.getName()).get();
+                      }
+              );
+    }
+    updatedNews.setCategory(category);
   }
 
   /**


### PR DESCRIPTION
- Se crea el endpoint para actualizar una entidad News.
- Se amplía la funcionalidad del service para lograr el objetivo.
- Se agrega el atributo id al DTO de Category.
- Algunos fixes chicos.

Nota: En cierta parte del proceso necesito traerme una entidad (no DTO) de Category al service de News. Decidí segregar una interfaz nueva para este propósito por temas de seguridad, para poder indicar que esta funcionalidad debería solamente ser accedida desde otro service (y no, por ej, desde algún controller). Si bien la impl implementa las dos interfaces, como los cliente utilizan solamente las interfaces y no la implementación, a menos que inyecten esta interfaz nueva, su funcionalidad estará "oculta" desde la otra interfaz.