### PR TITLE
Agregar paginación a Categorías (OT229-80)

### DIFF
--- a/src/main/java/com/alkemy/ong/controllers/CategoriesController.java
+++ b/src/main/java/com/alkemy/ong/controllers/CategoriesController.java
@@ -1,8 +1,7 @@
 package com.alkemy.ong.controllers;
 
-import com.alkemy.ong.dto.CategoryDTO;
-import com.alkemy.ong.dto.CategoryListResponse;
-import com.alkemy.ong.dto.DeleteEntityResponse;
+import com.alkemy.ong.dto.*;
+import com.alkemy.ong.exception.PageIndexOutOfBoundsException;
 import com.alkemy.ong.services.CategoriesService;
 import com.alkemy.ong.utility.GlobalConstants;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,11 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
-
-import java.io.IOException;
-import java.util.List;
 
 @RestController
 @RequestMapping(GlobalConstants.Endpoints.CATEGORIES)
@@ -60,13 +55,9 @@ public class CategoriesController {
 
     }
 
-    
     @GetMapping
-    public ResponseEntity<?> getCategoryList() {
-        CategoryListResponse responseBody = new CategoryListResponse();
-        responseBody.setCategories(this.categoriesService.getAllCategoryNames());
-        return ResponseEntity.ok(responseBody);
-
+    public ResponseEntity<?> getCategoryList(@RequestParam(value = GlobalConstants.PAGE_INDEX_PARAM) int page) throws PageIndexOutOfBoundsException {
+        return ResponseEntity.ok(this.categoriesService.getAllCategoryNames(page));
     }
 
     @DeleteMapping("{/id}")
@@ -78,4 +69,5 @@ public class CategoriesController {
         }
         return ResponseEntity.status(HttpStatus.OK).build();
     }
+
 }

--- a/src/main/java/com/alkemy/ong/dto/PageResultResponse.java
+++ b/src/main/java/com/alkemy/ong/dto/PageResultResponse.java
@@ -1,0 +1,51 @@
+package com.alkemy.ong.dto;
+
+import com.alkemy.ong.utility.GlobalConstants;
+import lombok.*;
+import lombok.experimental.Accessors;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Generic DTO to serve as the response body for all requests for paginated search results.
+ *
+ * @param <T>   the class of the listed elements in the page.
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class PageResultResponse<T> {
+
+    private List<T> content = new ArrayList<>();
+    @Setter(AccessLevel.NONE)
+    private String next_page_url;
+    @Setter(AccessLevel.NONE)
+    private String previous_page_url;
+
+    public PageResultResponse<T> setNextPageUrl(int currentPageNumber, boolean hasNext) {
+        if (hasNext) {
+            this.next_page_url = ServletUriComponentsBuilder.fromCurrentRequestUri()
+                    .replaceQueryParam(GlobalConstants.PAGE_INDEX_PARAM, currentPageNumber+1)
+                    .build()
+                    .encode()
+                    .toUriString();
+        }
+        return this;
+    }
+
+    public PageResultResponse<T> setPreviousPageUrl(int currentPageNumber, boolean hasPrevious) {
+        if (hasPrevious) {
+            this.previous_page_url = ServletUriComponentsBuilder.fromCurrentRequestUri()
+                    .replaceQueryParam(GlobalConstants.PAGE_INDEX_PARAM, currentPageNumber-1)
+                    .build()
+                    .encode()
+                    .toUriString();
+        }
+        return this;
+    }
+
+}

--- a/src/main/java/com/alkemy/ong/dto/PageResultResponse.java
+++ b/src/main/java/com/alkemy/ong/dto/PageResultResponse.java
@@ -21,31 +21,7 @@ import java.util.List;
 public class PageResultResponse<T> {
 
     private List<T> content = new ArrayList<>();
-    @Setter(AccessLevel.NONE)
     private String next_page_url;
-    @Setter(AccessLevel.NONE)
     private String previous_page_url;
-
-    public PageResultResponse<T> setNextPageUrl(int currentPageNumber, boolean hasNext) {
-        if (hasNext) {
-            this.next_page_url = ServletUriComponentsBuilder.fromCurrentRequestUri()
-                    .replaceQueryParam(GlobalConstants.PAGE_INDEX_PARAM, currentPageNumber+1)
-                    .build()
-                    .encode()
-                    .toUriString();
-        }
-        return this;
-    }
-
-    public PageResultResponse<T> setPreviousPageUrl(int currentPageNumber, boolean hasPrevious) {
-        if (hasPrevious) {
-            this.previous_page_url = ServletUriComponentsBuilder.fromCurrentRequestUri()
-                    .replaceQueryParam(GlobalConstants.PAGE_INDEX_PARAM, currentPageNumber-1)
-                    .build()
-                    .encode()
-                    .toUriString();
-        }
-        return this;
-    }
 
 }

--- a/src/main/java/com/alkemy/ong/exception/PageIndexOutOfBoundsException.java
+++ b/src/main/java/com/alkemy/ong/exception/PageIndexOutOfBoundsException.java
@@ -1,0 +1,26 @@
+package com.alkemy.ong.exception;
+
+/**
+ * Exception that indicates that the page number provided to perform a paginated search is not valid.
+ *
+ * This exception is caught by the Controller Advice and doesn't need handling.
+ */
+public class PageIndexOutOfBoundsException extends Exception {
+
+    public PageIndexOutOfBoundsException() {
+        super();
+    }
+
+    public PageIndexOutOfBoundsException(String message) {
+        super(message);
+    }
+
+    public PageIndexOutOfBoundsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PageIndexOutOfBoundsException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/com/alkemy/ong/mappers/PageResultResponseBuilder.java
+++ b/src/main/java/com/alkemy/ong/mappers/PageResultResponseBuilder.java
@@ -69,8 +69,7 @@ public class PageResultResponseBuilder<T, R> {
          * This sub-builder is intended to produce a result with converted elements.
          *
          * @param <T>   the class of the entities retrieved by the repository
-         * @param <R>   the class of the objects to be contained in the response. If the response content doesn't need to be
-         *              converted, then the same class as the original entities (T) can be provided again.
+         * @param <R>   the class of the objects that the entities will be converted to.
          */
         public static class MappedProvidedBuilder <T, R> {
 

--- a/src/main/java/com/alkemy/ong/mappers/PageResultResponseBuilder.java
+++ b/src/main/java/com/alkemy/ong/mappers/PageResultResponseBuilder.java
@@ -1,0 +1,105 @@
+package com.alkemy.ong.mappers;
+
+import com.alkemy.ong.dto.PageResultResponse;
+import org.springframework.data.domain.Page;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Builder to construct a PageResultResponse from a <code>org.springframework.data.domain.Page</code> which is returned
+ * as the result of a paginated search made by the repository.
+ *
+ * @param <T>   the class of the entities retrieved by the repository
+ * @param <R>   the class of the objects to be contained in the response. If the response content doesn't need to be
+ *              converted, then the same class as the original entities (T) can be provided again.
+ */
+public class PageResultResponseBuilder<T, R> {
+
+    /**
+     * Provides the original data source.
+     *
+     * @param springDataPage    the page returned by the repository's paginated search.
+     * @return  a sub-builder with the provided data source to continue the building process.
+     */
+    public ContentProvidedBuilder<T, R> from(Page<T> springDataPage) {
+        return new ContentProvidedBuilder<>(springDataPage);
+    }
+
+    /**
+     * Sub-Builder to construct a PageResultResponse, containing the data source.
+     *
+     * @param <T>   the class of the entities retrieved by the repository
+     * @param <R>   the class of the objects to be contained in the response. If the response content doesn't need to be
+     *              converted, then the same class as the original entities (T) can be provided again.
+     */
+    public static class ContentProvidedBuilder<T, R> {
+
+        private final Page<T> springDataPage;
+
+        public ContentProvidedBuilder(Page<T> springDataPage) {
+            this.springDataPage = springDataPage;
+        }
+
+        /**
+         * Provides a mapper function to convert the listed entities.
+         *
+         * @param entityMapperFunction  a mapper function to convert the entities of class T into objects of class R.
+         * @return  a sub-builder with both the data source and the mapper function to continue the building process.
+         */
+        public MappedProvidedBuilder <T, R> mapWith(Function<T, R> entityMapperFunction) {
+            return new MappedProvidedBuilder<>(this.springDataPage, entityMapperFunction);
+        }
+
+        /**
+         * Builds the PageResultResponse without converting the entities to another class.
+         *
+         * @return  a response with the original entities.
+         */
+        public PageResultResponse<T> build() {
+            return new PageResultResponse<T>()
+                    .setContent(this.springDataPage.getContent())
+                    .setNextPageUrl(this.springDataPage.getNumber(), this.springDataPage.hasNext())
+                    .setPreviousPageUrl(this.springDataPage.getNumber(), this.springDataPage.hasPrevious());
+        }
+
+        /**
+         * Sub-Builder to construct a PageResultResponse, containing the data source and the mapper function.
+         *
+         * This sub-builder is intended to produce a result with converted elements.
+         *
+         * @param <T>   the class of the entities retrieved by the repository
+         * @param <R>   the class of the objects to be contained in the response. If the response content doesn't need to be
+         *              converted, then the same class as the original entities (T) can be provided again.
+         */
+        public static class MappedProvidedBuilder <T, R> {
+
+            private final Page<T> springDataPage;
+            private final Function<T, R> entityMapperFunction;
+
+            public MappedProvidedBuilder(Page<T> springDataPage, Function<T, R> entityMapperFunction) {
+                this.springDataPage = springDataPage;
+                this.entityMapperFunction = entityMapperFunction;
+            }
+
+            /**
+             * Builds the PageResultResponse, mapping the contained entities into another class (probably a DTO or a String).
+             *
+             * @return  a response with the mapped objects.
+             */
+            public PageResultResponse<R> build() {
+                return new PageResultResponse<R>()
+                        .setContent(
+                                this.springDataPage.get()
+                                        .map(this.entityMapperFunction)
+                                        .collect(Collectors.toList())
+                        )
+                        .setNextPageUrl(this.springDataPage.getNumber(), this.springDataPage.hasNext())
+                        .setPreviousPageUrl(this.springDataPage.getNumber(), this.springDataPage.hasPrevious());
+            }
+
+        }
+
+    }
+
+}

--- a/src/main/java/com/alkemy/ong/repositories/CategoryRepository.java
+++ b/src/main/java/com/alkemy/ong/repositories/CategoryRepository.java
@@ -2,6 +2,8 @@
 package com.alkemy.ong.repositories;
 
 import com.alkemy.ong.entities.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,4 +21,7 @@ public interface CategoryRepository extends JpaRepository<Category, String> {
     Optional<Category> findByName(String name);
     
     List<Category> findAllByOrderByName();
+
+    Page<Category> findAll(Pageable pageable);
+
 }

--- a/src/main/java/com/alkemy/ong/security/configuration/ValidationControllerAdvice.java
+++ b/src/main/java/com/alkemy/ong/security/configuration/ValidationControllerAdvice.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -133,6 +134,20 @@ public class ValidationControllerAdvice {
             return e.getMessage().substring(0, e.getMessage().lastIndexOf("'") + 1) + " missing.";
         }
         return "Missing request param.";
+    }
+
+    /**
+     * Catches and processes the response for the exception thrown when a requested endpoint param is sent with a
+     * different type than the one specified in the method declaration.
+     *
+     * @param e the exception.
+     * @return  the response body.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    String onMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        return "Incorrect param type";
     }
 
 }

--- a/src/main/java/com/alkemy/ong/security/configuration/ValidationControllerAdvice.java
+++ b/src/main/java/com/alkemy/ong/security/configuration/ValidationControllerAdvice.java
@@ -3,6 +3,7 @@ package com.alkemy.ong.security.configuration;
 import com.alkemy.ong.exception.CloudStorageClientException;
 import com.alkemy.ong.exception.CorruptedFileException;
 import com.alkemy.ong.exception.FileNotFoundOnCloudException;
+import com.alkemy.ong.exception.PageIndexOutOfBoundsException;
 import com.alkemy.ong.security.payload.ValidationErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -101,6 +103,36 @@ public class ValidationControllerAdvice {
     @ResponseBody
     String onFileNotFoundOnCloudException(FileNotFoundOnCloudException e) {
         return "The file doesn't exist.";
+    }
+
+    /**
+     * Catches and processes the response for the exception thrown when the page number provided to perform a
+     * paginated search is not valid.
+     *
+     * @param e the exception.
+     * @return  the response body.
+     */
+    @ExceptionHandler(PageIndexOutOfBoundsException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseBody
+    String onPageIndexOutOfBoundsException(PageIndexOutOfBoundsException e) {
+        return e.getMessage();
+    }
+
+    /**
+     * Catches and processes the response for the exception thrown when a requested endpoint param is required but missing.
+     *
+     * @param e the exception.
+     * @return  the response body.
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    String onMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        if (e.getMessage() != null) {
+            return e.getMessage().substring(0, e.getMessage().lastIndexOf("'") + 1) + " missing.";
+        }
+        return "Missing request param.";
     }
 
 }

--- a/src/main/java/com/alkemy/ong/security/configuration/ValidationControllerAdvice.java
+++ b/src/main/java/com/alkemy/ong/security/configuration/ValidationControllerAdvice.java
@@ -113,7 +113,7 @@ public class ValidationControllerAdvice {
      * @return  the response body.
      */
     @ExceptionHandler(PageIndexOutOfBoundsException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ResponseBody
     String onPageIndexOutOfBoundsException(PageIndexOutOfBoundsException e) {
         return e.getMessage();

--- a/src/main/java/com/alkemy/ong/services/CategoriesService.java
+++ b/src/main/java/com/alkemy/ong/services/CategoriesService.java
@@ -30,5 +30,6 @@ public interface CategoriesService {
     PageResultResponse<String> getAllCategoryNames(int pageNumber) throws PageIndexOutOfBoundsException;
 
     public void deleteCategory(String id);
+
 }
 

--- a/src/main/java/com/alkemy/ong/services/CategoriesService.java
+++ b/src/main/java/com/alkemy/ong/services/CategoriesService.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.services;
 import com.alkemy.ong.dto.CategoryDTO;
+import com.alkemy.ong.dto.PageResultResponse;
+import com.alkemy.ong.exception.PageIndexOutOfBoundsException;
 
 import java.util.List;
 
@@ -13,6 +15,19 @@ public interface CategoriesService {
     public CategoryDTO edit (CategoryDTO dto, String id);
 
     List<String> getAllCategoryNames();
+
+    /**
+     * Performs a paginated search for all the Category entries in the database and returns their names and the urls
+     * to get the previous and next page results.
+     *
+     * <p>Page size and sorting criteria are read from global constants.
+     *
+     * @param pageNumber    the index of the page to be retrieved.
+     * @return  the list of category names. If the provided index exceeds the last existing index, an empty list will
+     *          be returned, and the previous page url attribute will point to the last available page.
+     * @throws PageIndexOutOfBoundsException    if the index is not a positive integer.
+     */
+    PageResultResponse<String> getAllCategoryNames(int pageNumber) throws PageIndexOutOfBoundsException;
 
     public void deleteCategory(String id);
 }

--- a/src/main/java/com/alkemy/ong/services/impl/CategoriesServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/CategoriesServiceImpl.java
@@ -1,16 +1,20 @@
 package com.alkemy.ong.services.impl;
 
 import com.alkemy.ong.dto.CategoryDTO;
+import com.alkemy.ong.dto.PageResultResponse;
 import com.alkemy.ong.entities.Category;
+import com.alkemy.ong.exception.PageIndexOutOfBoundsException;
 import com.alkemy.ong.mappers.CategoryMapper;
+import com.alkemy.ong.mappers.PageResultResponseBuilder;
 import com.alkemy.ong.repositories.CategoryRepository;
 import com.alkemy.ong.repositories.NewsRepository;
 import com.alkemy.ong.services.CategoriesService;
 import com.alkemy.ong.services.CategoryEntityProvider;
+import com.alkemy.ong.utility.GlobalConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
-import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
 
 import java.util.List;
@@ -80,6 +84,23 @@ public class CategoriesServiceImpl implements CategoriesService, CategoryEntityP
                 .map(Category::getName)
                 .collect(Collectors.toList());
 
+    }
+
+    @Override
+    public PageResultResponse<String> getAllCategoryNames(int pageNumber) throws PageIndexOutOfBoundsException {
+        if (pageNumber < 0) {
+            throw new PageIndexOutOfBoundsException("Page number must be positive.");
+        }
+        Pageable pageRequest = PageRequest.of(
+                pageNumber,
+                GlobalConstants.GLOBAL_PAGE_SIZE,
+                Sort.by(GlobalConstants.CATEGORY_SORT_ATTRIBUTE)
+        );
+        Page<Category> springDataResultPage = this.categoryRepository.findAll(pageRequest);
+        return new PageResultResponseBuilder<Category, String>()
+                .from(springDataResultPage)
+                .mapWith(Category::getName)
+                .build();
     }
 
     @Transactional

--- a/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
+++ b/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
@@ -12,6 +12,11 @@ public abstract class GlobalConstants {
     public static final String TITLE_EMAIL_WELCOME = "Welcome! Thank you for registering";
     public static final String TITLE_EMAIL_CONTACT = "Thank you for contacting us! We will be answering your query shortly";
 
+    // Pagination
+    public static final int GLOBAL_PAGE_SIZE = 10;
+    public static final String PAGE_INDEX_PARAM = "page";
+    public static final String CATEGORY_SORT_ATTRIBUTE = "name";
+
     public static abstract class Endpoints {
 
         public static final String LOGIN = "/auth/login";


### PR DESCRIPTION
Se agrega la característica de paginación al endpoint existente que devolvía todas las categorías.

Los elementos para la búsqueda paginados fueron creados con generics así que pueden reutilizarse en la implementación de todas las demás búsquedas paginadas.