### PR TITLE
Agregar paginación a Novedades (OT229-81)

### DIFF
--- a/src/main/java/com/alkemy/ong/controllers/NewsController.java
+++ b/src/main/java/com/alkemy/ong/controllers/NewsController.java
@@ -4,6 +4,7 @@ import com.alkemy.ong.dto.DeleteEntityResponse;
 import com.alkemy.ong.dto.NewsDTO;
 import com.alkemy.ong.exception.CloudStorageClientException;
 import com.alkemy.ong.exception.CorruptedFileException;
+import com.alkemy.ong.exception.PageIndexOutOfBoundsException;
 import com.alkemy.ong.services.CloudStorageService;
 import com.alkemy.ong.services.NewsService;
 import com.alkemy.ong.utility.GlobalConstants;
@@ -69,6 +70,11 @@ public class NewsController {
     } catch (IllegalArgumentException e) {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
+  }
+
+  @GetMapping
+  public ResponseEntity<?> getAllNews(@RequestParam(value = GlobalConstants.PAGE_INDEX_PARAM) int page) throws PageIndexOutOfBoundsException {
+    return ResponseEntity.ok( this.newsService.getAllNews(page) );
   }
 
 }

--- a/src/main/java/com/alkemy/ong/dto/DatedNewsDTO.java
+++ b/src/main/java/com/alkemy/ong/dto/DatedNewsDTO.java
@@ -1,0 +1,15 @@
+package com.alkemy.ong.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Extension of the previous NewsDTO with the inclusion of the timestamp attribute.
+ */
+@Getter
+@Setter
+public class DatedNewsDTO extends NewsDTO {
+
+    private String timestamp;
+
+}

--- a/src/main/java/com/alkemy/ong/mappers/NewsMapper.java
+++ b/src/main/java/com/alkemy/ong/mappers/NewsMapper.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.mappers;
 
+import com.alkemy.ong.dto.DatedNewsDTO;
 import com.alkemy.ong.dto.NewsDTO;
 import com.alkemy.ong.entities.News;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +37,17 @@ public class NewsMapper {
     newsToBeUpdated.setContent(updatedNews.getContent());
     newsToBeUpdated.setImage(updatedNews.getImage());
     newsToBeUpdated.setCategory(this.categoryMapper.categoryDTO2Entity(updatedNews.getCategory()));
+  }
+
+  public DatedNewsDTO newsEntity2DatedDTO(News entity) {
+    DatedNewsDTO dto = new DatedNewsDTO();
+    dto.setId(entity.getId());
+    dto.setName(entity.getName());
+    dto.setContent(entity.getContent());
+    dto.setImage(entity.getImage());
+    dto.setCategory(this.categoryMapper.categoryEntity2DTO(entity.getCategory()));
+    dto.setTimestamp( entity.getTimestamp().toString() );
+    return dto;
   }
 
 }

--- a/src/main/java/com/alkemy/ong/repositories/NewsRepository.java
+++ b/src/main/java/com/alkemy/ong/repositories/NewsRepository.java
@@ -1,6 +1,8 @@
 package com.alkemy.ong.repositories;
 
 import com.alkemy.ong.entities.News;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,5 +19,7 @@ public interface NewsRepository extends JpaRepository<News,String> {
     @Modifying
     @Query("update News n set n.category = null where n.category.id = :id")
     void detachCategory(@Param(value ="id")String id);
+
+    Page<News> findAll(Pageable pageRequest);
 
 }

--- a/src/main/java/com/alkemy/ong/services/NewsService.java
+++ b/src/main/java/com/alkemy/ong/services/NewsService.java
@@ -1,8 +1,10 @@
 package com.alkemy.ong.services;
 
 import com.alkemy.ong.dto.NewsDTO;
+import com.alkemy.ong.dto.PageResultResponse;
 import com.alkemy.ong.exception.CloudStorageClientException;
 import com.alkemy.ong.exception.CorruptedFileException;
+import com.alkemy.ong.exception.PageIndexOutOfBoundsException;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityNotFoundException;
@@ -36,5 +38,17 @@ public interface NewsService {
    * @throws IllegalArgumentException if the News' Category to be updated is present but has an invalid name.
    */
   NewsDTO updateNews(String id, MultipartFile image, NewsDTO updatedNews) throws EntityNotFoundException, IllegalArgumentException, CloudStorageClientException, CorruptedFileException;
+
+  /**
+   * Performs a paginated search for all the News entries in the database and returns them alongside the urls
+   * to get the previous and next page results.
+   *
+   * <p>Page size and sorting criteria are read from global constants.
+   * @param pageNumber  the index of the page to be retrieved.
+   * @return the list of News. If the provided index exceeds the last existing index, an empty list will
+   *          be returned, and the previous page url attribute will point to the last available page.
+   * @throws PageIndexOutOfBoundsException  if the index is not a positive integer.
+   */
+  PageResultResponse<NewsDTO> getAllNews(int pageNumber) throws PageIndexOutOfBoundsException;
 
 }

--- a/src/main/java/com/alkemy/ong/services/NewsService.java
+++ b/src/main/java/com/alkemy/ong/services/NewsService.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.services;
 
+import com.alkemy.ong.dto.DatedNewsDTO;
 import com.alkemy.ong.dto.NewsDTO;
 import com.alkemy.ong.dto.PageResultResponse;
 import com.alkemy.ong.exception.CloudStorageClientException;
@@ -49,6 +50,6 @@ public interface NewsService {
    *          be returned, and the previous page url attribute will point to the last available page.
    * @throws PageIndexOutOfBoundsException  if the index is not a positive integer.
    */
-  PageResultResponse<NewsDTO> getAllNews(int pageNumber) throws PageIndexOutOfBoundsException;
+  PageResultResponse<DatedNewsDTO> getAllNews(int pageNumber) throws PageIndexOutOfBoundsException;
 
 }

--- a/src/main/java/com/alkemy/ong/services/impl/NewsServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/NewsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.services.impl;
 
 import com.alkemy.ong.dto.CategoryDTO;
+import com.alkemy.ong.dto.DatedNewsDTO;
 import com.alkemy.ong.dto.NewsDTO;
 import com.alkemy.ong.dto.PageResultResponse;
 import com.alkemy.ong.entities.Category;
@@ -102,7 +103,7 @@ public class NewsServiceImpl implements NewsService {
   }
 
   @Override
-  public PageResultResponse<NewsDTO> getAllNews(int pageNumber) throws PageIndexOutOfBoundsException {
+  public PageResultResponse<DatedNewsDTO> getAllNews(int pageNumber) throws PageIndexOutOfBoundsException {
     if (pageNumber < 0) {
       throw new PageIndexOutOfBoundsException("Page number must be positive.");
     }
@@ -112,9 +113,9 @@ public class NewsServiceImpl implements NewsService {
             Sort.by(GlobalConstants.NEWS_SORT_ATTRIBUTE)
     );
     Page<News> springDataResultPage = this.newsRepository.findAll(pageRequest);
-    return new PageResultResponseBuilder<News, NewsDTO>()
+    return new PageResultResponseBuilder<News, DatedNewsDTO>()
             .from(springDataResultPage)
-            .mapWith(this.newsMapper::newsEntity2DTO)
+            .mapWith(this.newsMapper::newsEntity2DatedDTO)
             .build();
   }
 

--- a/src/main/java/com/alkemy/ong/services/impl/NewsServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/NewsServiceImpl.java
@@ -2,20 +2,24 @@ package com.alkemy.ong.services.impl;
 
 import com.alkemy.ong.dto.CategoryDTO;
 import com.alkemy.ong.dto.NewsDTO;
+import com.alkemy.ong.dto.PageResultResponse;
 import com.alkemy.ong.entities.Category;
 import com.alkemy.ong.entities.News;
-import com.alkemy.ong.exception.CloudStorageClientException;
-import com.alkemy.ong.exception.CorruptedFileException;
-import com.alkemy.ong.exception.EntityImageProcessingException;
-import com.alkemy.ong.exception.FileNotFoundOnCloudException;
+import com.alkemy.ong.exception.*;
 import com.alkemy.ong.mappers.CategoryMapper;
 import com.alkemy.ong.mappers.NewsMapper;
+import com.alkemy.ong.mappers.PageResultResponseBuilder;
 import com.alkemy.ong.repositories.NewsRepository;
 import com.alkemy.ong.services.CategoriesService;
 import com.alkemy.ong.services.CategoryEntityProvider;
 import com.alkemy.ong.services.CloudStorageService;
 import com.alkemy.ong.services.NewsService;
+import com.alkemy.ong.utility.GlobalConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -95,6 +99,23 @@ public class NewsServiceImpl implements NewsService {
     }
     updatedNews.setImage(updatedImageUrl);
     return this.newsMapper.newsEntity2DTO(newsToUpdate);
+  }
+
+  @Override
+  public PageResultResponse<NewsDTO> getAllNews(int pageNumber) throws PageIndexOutOfBoundsException {
+    if (pageNumber < 0) {
+      throw new PageIndexOutOfBoundsException("Page number must be positive.");
+    }
+    Pageable pageRequest = PageRequest.of(
+            pageNumber,
+            GlobalConstants.GLOBAL_PAGE_SIZE,
+            Sort.by(GlobalConstants.NEWS_SORT_ATTRIBUTE)
+    );
+    Page<News> springDataResultPage = this.newsRepository.findAll(pageRequest);
+    return new PageResultResponseBuilder<News, NewsDTO>()
+            .from(springDataResultPage)
+            .mapWith(this.newsMapper::newsEntity2DTO)
+            .build();
   }
 
   /**

--- a/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
+++ b/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
@@ -16,6 +16,7 @@ public abstract class GlobalConstants {
     public static final int GLOBAL_PAGE_SIZE = 10;
     public static final String PAGE_INDEX_PARAM = "page";
     public static final String CATEGORY_SORT_ATTRIBUTE = "name";
+    public static final String NEWS_SORT_ATTRIBUTE = "timestamp";
 
     public static abstract class Endpoints {
         public static final String LOGIN = "/auth/login";


### PR DESCRIPTION
Se agrega la paginación al método de listar novedades.

Me encontré con que, a diferencia de los otros tickets de paginación que agregan esta característica a métodos de listar ya implementados, el método de listar novedades no existía... ni tampoco estaba indicado en ningún ticket. Así que fue creado.

Se reutilizan los elementos de paginación genéricos existentes, así que nada relacionado a la paginación misma fue creado o modificado. Solamente se agregaron los métodos correspondientes en los controller, service y repository.

Se extendió el DTO para mostrar el timestamp de los elementos, cosa que es importante para cosas como novedades.