### PR TITLE
OT229-78 Endpoint Eliminación Comentarios

### DIFF
--- a/src/main/java/com/alkemy/ong/controllers/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controllers/CommentController.java
@@ -19,8 +19,7 @@ public class CommentController {
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteComment(@PathVariable String id, @RequestHeader("authorization") String token) throws Exception {
         try{
-            commentService.deleteComment(id, token);
-            return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+            return ResponseEntity.status(HttpStatus.ACCEPTED).body(commentService.deleteComment(id, token));
         }catch (EntityNotFoundException e){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }catch (Exception e){

--- a/src/main/java/com/alkemy/ong/controllers/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controllers/CommentController.java
@@ -19,7 +19,7 @@ public class CommentController {
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteComment(@PathVariable String id, @RequestHeader("authorization") String token) throws Exception {
         try{
-            return ResponseEntity.status(HttpStatus.ACCEPTED).body(commentService.deleteComment(id, token));
+            return ResponseEntity.status(HttpStatus.OK).body(commentService.deleteComment(id, token));
         }catch (EntityNotFoundException e){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }catch (Exception e){

--- a/src/main/java/com/alkemy/ong/controllers/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controllers/CommentController.java
@@ -1,0 +1,30 @@
+package com.alkemy.ong.controllers;
+
+import com.alkemy.ong.services.CommentService;
+import com.alkemy.ong.utility.GlobalConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.persistence.EntityNotFoundException;
+
+@RestController
+@RequestMapping(GlobalConstants.Endpoints.COMMENTS)
+public class CommentController {
+
+    @Autowired
+    CommentService commentService;
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteComment(@PathVariable String id, @RequestHeader("authorization") String token) throws Exception {
+        try{
+            commentService.deleteComment(id, token);
+            return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+        }catch (EntityNotFoundException e){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/alkemy/ong/entities/CommentEntity.java
+++ b/src/main/java/com/alkemy/ong/entities/CommentEntity.java
@@ -21,13 +21,13 @@ public class CommentEntity {
   @Column(name = "id")
   private String id;
 
-  @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+  @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.MERGE)
   @JoinColumn(name = "user_id", insertable = false, updatable = false)
   private User user;
   @Column(name = "user_id", nullable = false)
   private String userId;
 
-  @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+  @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.MERGE)
   @JoinColumn(name = "news_id", insertable = false, updatable = false)
   private News news;
   @Column(name = "news_id", nullable = false)

--- a/src/main/java/com/alkemy/ong/security/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/alkemy/ong/security/configuration/SecurityConfiguration.java
@@ -63,10 +63,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 
                                 // Permitted access to a USER
-                                .antMatchers(HttpMethod.GET, GlobalConstants.EndpointsRoutes.USER_GET).hasAnyAuthority(GlobalConstants.ROLE_USER)
-                                .antMatchers(HttpMethod.POST, GlobalConstants.EndpointsRoutes.USER_POST).hasAnyAuthority(GlobalConstants.ROLE_USER)
-                                .antMatchers(HttpMethod.PUT, GlobalConstants.EndpointsRoutes.USER_PUT).hasAnyAuthority(GlobalConstants.ROLE_USER)
-                                .antMatchers(HttpMethod.DELETE, GlobalConstants.EndpointsRoutes.USER_DELETE).hasAnyAuthority(GlobalConstants.ROLE_USER)
+                                .antMatchers(HttpMethod.GET, GlobalConstants.EndpointsRoutes.USER_GET).hasAnyAuthority(GlobalConstants.ALL_ROLES)
+                                .antMatchers(HttpMethod.POST, GlobalConstants.EndpointsRoutes.USER_POST).hasAnyAuthority(GlobalConstants.ALL_ROLES)
+                                .antMatchers(HttpMethod.PUT, GlobalConstants.EndpointsRoutes.USER_PUT).hasAnyAuthority(GlobalConstants.ALL_ROLES)
+                                .antMatchers(HttpMethod.DELETE, GlobalConstants.EndpointsRoutes.USER_DELETE).hasAnyAuthority(GlobalConstants.ALL_ROLES)
 
                                 // ADMIN access -> can do all
                                 .antMatchers(HttpMethod.GET, "/**").hasAnyAuthority(GlobalConstants.ROLE_ADMIN)

--- a/src/main/java/com/alkemy/ong/services/CommentService.java
+++ b/src/main/java/com/alkemy/ong/services/CommentService.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Service;
 public interface CommentService {
   public CommentDTO save (CommentDTO commentDTO) throws Exception;
 
-    void deleteComment(String idComentary, String token) throws Exception;
+    String deleteComment(String idComentary, String token) throws Exception;
 }

--- a/src/main/java/com/alkemy/ong/services/CommentService.java
+++ b/src/main/java/com/alkemy/ong/services/CommentService.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Service;
 @Service
 public interface CommentService {
   public CommentDTO save (CommentDTO commentDTO) throws Exception;
+
+    void deleteComment(String idComentary, String token) throws Exception;
 }

--- a/src/main/java/com/alkemy/ong/services/CommentService.java
+++ b/src/main/java/com/alkemy/ong/services/CommentService.java
@@ -5,7 +5,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface CommentService {
-  public CommentDTO save (CommentDTO commentDTO) throws Exception;
+
+    public CommentDTO save (CommentDTO commentDTO) throws Exception;
 
     String deleteComment(String idComentary, String token) throws Exception;
 }

--- a/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
@@ -1,0 +1,44 @@
+package com.alkemy.ong.services.impl;
+
+import com.alkemy.ong.entities.User;
+import com.alkemy.ong.security.service.JwtService;
+import com.alkemy.ong.services.CommentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+
+@Service
+public class CommentServiceImpl implements CommentService {
+
+    @Autowired
+    JwtService jwtService;
+
+    @Autowired
+    UserServiceImpl userService;
+
+    @Override
+    public void deleteComment(String idComentary, String token) throws Exception {
+        try{
+            // Buscar el comentario por ID, buscar los roles del usuario
+        }catch (EntityNotFoundException e){
+            throw new EntityNotFoundException("Comment with the provided ID not present");
+        }
+        // Extraigo los roles
+        List<String> roles = jwtService.getRoles(token);
+
+        // Extraigo el usarname para saber si es propietario del comentario
+        String userName = jwtService.getUsername(token); // El username del token es el correo
+        User user = userService.getUserByEmail(userName).get();
+
+        // Si es administrador lo puede eliminar
+        if(roles.contains("ROLE_ADMIN")){
+            // Lo elimina
+        }else if(true){ // Verifico si es el propietario del comentario
+            // comment.getUserId().equals(user.getId()) -> delete
+        }else{
+            throw new Exception("You don't have permissions to delete this comment");
+        }
+    }
+}

--- a/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
@@ -19,7 +19,7 @@ public class CommentServiceImpl implements CommentService {
     UserServiceImpl userService;
 
     @Override
-    public void deleteComment(String idComentary, String token) throws Exception {
+    public String deleteComment(String idComentary, String token) throws Exception {
         try{
             // Buscar el comentario por ID, buscar los roles del usuario
         }catch (EntityNotFoundException e){
@@ -35,8 +35,10 @@ public class CommentServiceImpl implements CommentService {
         // Si es administrador lo puede eliminar
         if(roles.contains("ROLE_ADMIN")){
             // Lo elimina
+            return "Successfully deleted comment";
         }else if(true){ // Verifico si es el propietario del comentario
             // comment.getUserId().equals(user.getId()) -> delete
+            return "Successfully deleted comment";
         }else{
             throw new Exception("You don't have permissions to delete this comment");
         }

--- a/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
+++ b/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
@@ -5,6 +5,7 @@ public abstract class GlobalConstants {
     //  Default role names
     public static final String ROLE_ADMIN = "ROLE_ADMIN";
     public static final String ROLE_USER = "ROLE_USER";
+    public static final String[] ALL_ROLES = {"ROLE_USER", "ROLE_ADMIN"};
 
     // Send email
     public static final String TEMPLATE_CONTACT = "CONTACT";

--- a/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
+++ b/src/main/java/com/alkemy/ong/utility/GlobalConstants.java
@@ -30,8 +30,8 @@ public abstract class GlobalConstants {
         public static final String ACTIVITIES = "/activities";
         public static final String SLIDES = "/slides";
         public static final String TESTIMONIALS="/testimonials";
-
         public static final String MEMBERS= "/members";
+        public static final String COMMENTS = "/comments";
 
     }
 


### PR DESCRIPTION
**Descripción**

- Se agregó el método "deleteComment" en la interfaz y se implementó con su lógica.
- Se creó el controlador "CommentController".
- Se creó el endpoint DELETE para eliminar un comentario.

**Código de errores**

- 200 (OK) -> Comentario eliminado correctamente.
- 403 (FORBIDDEN) -> Se lanza si el que intenta eliminar el comentario no es el propietario o administrador.
- 404 (NOT FOUND) -> Si se intenta eliminar un comentario inexistente.


**Cambios menores que impedían el correcto funcionamiento**

  Seguridad

-   Se cambió la especificación de acceso en los lugares que puede acceder el usuario. Sucedía que como usuario se podía acceder al endpint DELETE pero no como administrador. Se tuvo que especificar que roles aparte del ROLE_USUARIO tienen acceso.

 CommentEntity

- Se cambió el tipo de cascada (CascadeType.ALL -> CascadeType.MERGE) ya que al momento de crear un comentario se lanzaba el error que decía "detached entity passed to persist". 