### PR TITLE
OT229-77-78 Mejora

### DIFF
--- a/src/main/java/com/alkemy/ong/controllers/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controllers/CommentController.java
@@ -39,10 +39,9 @@ public class CommentController {
     }
 
     @PutMapping(GlobalConstants.Endpoints.COMMENTS + "/{id}")
-    public ResponseEntity<?> updateComment(@PathVariable String id, @RequestParam(value = "commentBody", required = true) String commentBody,
-                                           @RequestHeader("authorization") String token) throws Exception{
+    public ResponseEntity<?> updateComment(@PathVariable String id, @RequestParam(value = "commentBody", required = true) String commentBody) throws Exception{
         try{
-            return ResponseEntity.status(HttpStatus.OK).body(commentService.updateComment(id, commentBody, token));
+            return ResponseEntity.status(HttpStatus.OK).body(commentService.updateComment(id, commentBody));
         }catch (EntityNotFoundException e){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }catch (Exception e){
@@ -51,9 +50,9 @@ public class CommentController {
     }
     
     @DeleteMapping(GlobalConstants.Endpoints.COMMENTS + "/{id}")
-    public ResponseEntity<?> deleteComment(@PathVariable String id, @RequestHeader("authorization") String token) throws Exception {
+    public ResponseEntity<?> deleteComment(@PathVariable String id) throws Exception {
         try{
-            return ResponseEntity.status(HttpStatus.OK).body(commentService.deleteComment(id, token));
+            return ResponseEntity.status(HttpStatus.OK).body(commentService.deleteComment(id));
         }catch (EntityNotFoundException e){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }catch (Exception e){

--- a/src/main/java/com/alkemy/ong/security/service/AuthenticationService.java
+++ b/src/main/java/com/alkemy/ong/security/service/AuthenticationService.java
@@ -1,8 +1,11 @@
 package com.alkemy.ong.security.service;
 
+import com.alkemy.ong.entities.User;
 import com.alkemy.ong.security.payload.LoginResponse;
 import org.springframework.security.core.AuthenticationException;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -39,4 +42,5 @@ public interface AuthenticationService {
      */
     boolean authUserMatchesId(String id) throws IllegalStateException;
 
+    User getAuthenticatedUserEntity() throws IllegalStateException;
 }

--- a/src/main/java/com/alkemy/ong/security/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/security/service/impl/AuthenticationServiceImpl.java
@@ -15,7 +15,11 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class AuthenticationServiceImpl implements AuthenticationService {
@@ -83,4 +87,24 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         return authUser.getId().equals(id);
     }
 
+    @Override
+    public User getAuthenticatedUserEntity() throws IllegalStateException{
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            return null;
+        }
+
+        String authUserEmail;
+        try{
+            authUserEmail = ((org.springframework.security.core.userdetails.User) authentication.getPrincipal())
+                .getUsername();
+        } catch (ClassCastException e) {
+            authUserEmail = (String) authentication.getPrincipal();
+        }
+
+        User authUser = this.userService.getUserByEmail(authUserEmail)
+                .orElseThrow(() -> new IllegalStateException("A user is authenticated but can't be retrieved from the database."));
+
+        return authUser;
+    }
 }

--- a/src/main/java/com/alkemy/ong/services/CommentService.java
+++ b/src/main/java/com/alkemy/ong/services/CommentService.java
@@ -22,9 +22,9 @@ public interface CommentService {
 
     List<CommentDTO> commentList(String idPost) throws Exception;
 
-    CommentDTO updateComment(String idComentary, String token, String newCommentBody) throws Exception;
+    CommentDTO updateComment(String idComentary, String newCommentBody) throws Exception;
     
-    String deleteComment(String idComentary, String token) throws Exception;
+    String deleteComment(String idComentary) throws Exception;
 
     List<CommentDTOList>getAll();
 }

--- a/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
@@ -92,7 +92,7 @@ public class CommentServiceImpl implements CommentService {
             if(checkPermissions(roles, commentFound.get().getUserId(), user.getId())){
                 commentFound.get().setBody(newCommentBody);
 
-                //commentRepository.save(commentFound.get());
+                commentRepository.save(commentFound.get());
                 return commentMapper.entity2DTO(commentFound.get());
             }else{
                 throw new Exception("You don't have permissions to edit this comment");
@@ -115,7 +115,7 @@ public class CommentServiceImpl implements CommentService {
             User user = userService.getUserByEmail(userName).get();
 
             if(checkPermissions(roles, commentFound.get().getUserId(), user.getId())){
-                //commentRepository.deleteById(commentFound.get().getId());
+                commentRepository.deleteById(commentFound.get().getId());
                 return "Successfully deleted comment";
 
             }else{

--- a/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
@@ -7,7 +7,6 @@ import com.alkemy.ong.entities.User;
 import com.alkemy.ong.mappers.CommentMapper;
 import com.alkemy.ong.repositories.CommentRepository;
 import com.alkemy.ong.security.service.AuthenticationService;
-import com.alkemy.ong.security.service.JwtService;
 import com.alkemy.ong.services.CommentService;
 import com.alkemy.ong.services.NewsService;
 import com.alkemy.ong.services.UserService;
@@ -28,9 +27,6 @@ public class CommentServiceImpl implements CommentService {
 
     @Autowired
     CommentMapper commentMapper;
-
-    @Autowired
-    JwtService jwtService;
 
     @Autowired
     UserService userService;


### PR DESCRIPTION
Los cambios que he hecho harían el código un poco más eficiente, ya que anteriormente se procesaba 2 veces el token. Una vez para autenticar el usuario y otra para saber que roles y correo tiene el usuario que ejecuta una petición de los endpoint PUT o DELETE del controlador de comentarios.
Ahora solamente se procesa el token al momento de autenticar al usuario, y luego se utiliza esa misma autenticación para obtener la información necesaria para validar si tiene permiso o no realizar la eliminación o edición de un comentario