### PR TITLE
Agregado el soporte de Swagger para JWT

### DIFF
--- a/src/main/java/com/alkemy/ong/configuration/OpenApiConfiguration.java
+++ b/src/main/java/com/alkemy/ong/configuration/OpenApiConfiguration.java
@@ -1,0 +1,18 @@
+package com.alkemy.ong.configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "OT229", version = "0.1.0"))
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        bearerFormat = "JWT",
+        scheme = "bearer"
+)
+public class OpenApiConfiguration {
+}

--- a/src/main/java/com/alkemy/ong/security/controller/AuthController.java
+++ b/src/main/java/com/alkemy/ong/security/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.alkemy.ong.security.service.AuthenticationService;
 import com.alkemy.ong.services.UserService;
 import com.alkemy.ong.utility.GlobalConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.*;
@@ -44,7 +45,7 @@ public class AuthController {
           }
     }
 
-    @PostMapping(GlobalConstants.Endpoints.LOGIN)
+    @PostMapping(value = GlobalConstants.Endpoints.LOGIN, consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public ResponseEntity<?> login(@Valid LoginRequest loginForm) {
 
         try {


### PR DESCRIPTION
Ahora en la UI de swagger van a ver este botón:

![Boton de auth](https://i.imgur.com/B858e3j.jpeg)

Si le dan click se va a abrir la interfaz para ingresar el token. Una vez que setean el token, ese token se aplica para todos los endpoints, así que cuando prueban un endpoint no necesitan ingresarlo nuevamente.

Apliqué tb un pequeño fix para que tome el body del endpoint de login, así que ya pueden testear la funcionalidad logueandose con un user, copiando el token e ingresándolo con el botón de arriba para desbloquear los endpoints que piden autenticación.

PARA DOCUMENTAR CON JWT CADA ENDPOINT que está asegurado, tienen que agregar esta línea de security a los argumentos de la etiqueta de documentación `@Operation` del método:

    @Operation(summary = "Una descripción", security = @SecurityRequirement(name = "bearerAuth"))
        public ResponseEntity<?> unMetodoDelControllerQueEstaAseguradoConJwt() {
    }