### PR TITLE
Refactor recepcion de imagenes - de MultipartFile separado a String base64 metido en DTO

### DIFF
--- a/src/main/java/com/alkemy/ong/controllers/ActivitiesController.java
+++ b/src/main/java/com/alkemy/ong/controllers/ActivitiesController.java
@@ -1,6 +1,6 @@
 package com.alkemy.ong.controllers;
 
-import com.alkemy.ong.dto.ActivityDTO;
+import com.alkemy.ong.dto.ActivityDTORequest;
 import com.alkemy.ong.exception.ActivityNamePresentException;
 import com.alkemy.ong.exception.ActivityNotFoundException;
 import com.alkemy.ong.exception.CloudStorageClientException;
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.io.IOException;
@@ -24,12 +23,11 @@ public class ActivitiesController {
     private ActivitiesService activitiesService;
 
     @PostMapping
-    public ResponseEntity<?> save(@RequestParam(value = "file", required = false) MultipartFile file,
-                                   @Valid @ModelAttribute ActivityDTO dto) throws CloudStorageClientException, CorruptedFileException {
+    public ResponseEntity<?> save(@Valid @RequestBody ActivityDTORequest dto) throws CloudStorageClientException, CorruptedFileException {
 
         try {
 
-            return ResponseEntity.status(HttpStatus.CREATED).body(activitiesService.save(file,dto));
+            return ResponseEntity.status(HttpStatus.CREATED).body(activitiesService.save(dto));
 
         } catch (ActivityNamePresentException e) {
 
@@ -40,12 +38,11 @@ public class ActivitiesController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> edit (@RequestParam(value = "file", required = false) MultipartFile file,
-                                   @Valid @ModelAttribute ActivityDTO dto, @PathVariable String id) throws CloudStorageClientException, CorruptedFileException {
+    public ResponseEntity<?> edit (@Valid @RequestBody ActivityDTORequest dto, @PathVariable String id) throws CloudStorageClientException, CorruptedFileException {
 
         try {
 
-            return ResponseEntity.status(HttpStatus.OK).body(activitiesService.edit(file,dto,id));
+            return ResponseEntity.status(HttpStatus.OK).body(activitiesService.edit(dto,id));
 
         } catch (ActivityNotFoundException e) {
 

--- a/src/main/java/com/alkemy/ong/controllers/MemberController.java
+++ b/src/main/java/com/alkemy/ong/controllers/MemberController.java
@@ -13,8 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
 
@@ -25,9 +23,9 @@ public class MemberController {
     private MemberService memberService;
 
     @PostMapping
-    public ResponseEntity createMember(@RequestParam(value = "file" , required = false) MultipartFile file,@Valid @ModelAttribute MemberDTORequest memberDTORequest){
+    public ResponseEntity createMember(@Valid @RequestBody MemberDTORequest memberDTORequest){
         try {
-            return new ResponseEntity<>(memberService.create(file,memberDTORequest), HttpStatus.CREATED);
+            return new ResponseEntity<>(memberService.create(memberDTORequest), HttpStatus.CREATED);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         }
@@ -53,9 +51,9 @@ public class MemberController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity editMember(@RequestParam(value = "file", required = false) MultipartFile file, @Valid @ModelAttribute MemberDTORequest request , @PathVariable String id) {
+    public ResponseEntity editMember(@Valid @RequestBody MemberDTORequest request , @PathVariable String id) {
         try {
-            return new ResponseEntity<>(memberService.edit(file,request,id), HttpStatus.OK);
+            return new ResponseEntity<>(memberService.edit(request,id), HttpStatus.OK);
         } catch (MemberNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         } catch (Exception e) {

--- a/src/main/java/com/alkemy/ong/controllers/NewsController.java
+++ b/src/main/java/com/alkemy/ong/controllers/NewsController.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.controllers;
 
 import com.alkemy.ong.dto.DeleteEntityResponse;
 import com.alkemy.ong.dto.NewsDTO;
+import com.alkemy.ong.dto.NewsDTORequest;
 import com.alkemy.ong.exception.CloudStorageClientException;
 import com.alkemy.ong.exception.CorruptedFileException;
 import com.alkemy.ong.exception.PageIndexOutOfBoundsException;
@@ -12,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
@@ -29,11 +29,8 @@ public class NewsController {
 
 
   @PostMapping
-  public ResponseEntity<NewsDTO> save(@RequestParam(value = "file",required = false) MultipartFile file, @ModelAttribute NewsDTO newsDTO) throws Exception{
-
-    newsDTO.setImage(cloudStorageService.uploadFile(file));
-    return ResponseEntity.status(HttpStatus.CREATED).body(this.newsService.save(file,newsDTO));
-
+  public ResponseEntity<NewsDTO> save(@Valid @RequestBody NewsDTORequest newsDTO) throws Exception{
+    return ResponseEntity.status(HttpStatus.CREATED).body(this.newsService.save(newsDTO));
   }
 
   @GetMapping("/{id}")
@@ -59,12 +56,11 @@ public class NewsController {
   }
 
   @PutMapping("/{id}")
-  public ResponseEntity<?> updateNews(@RequestParam(value = "file", required = false) MultipartFile file,
-                                      @Valid @ModelAttribute NewsDTO updatedNews,
+  public ResponseEntity<?> updateNews(@Valid @RequestBody NewsDTORequest updatedNews,
                                       @PathVariable String id) throws CloudStorageClientException, CorruptedFileException {
 
     try {
-      return ResponseEntity.ok(this.newsService.updateNews(id, file, updatedNews));
+      return ResponseEntity.ok(this.newsService.updateNews(id, updatedNews));
     } catch (EntityNotFoundException e) {
       return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     } catch (IllegalArgumentException e) {

--- a/src/main/java/com/alkemy/ong/controllers/OrganizationController.java
+++ b/src/main/java/com/alkemy/ong/controllers/OrganizationController.java
@@ -1,9 +1,6 @@
 package com.alkemy.ong.controllers;
 
-import com.alkemy.ong.dto.OrganizationDTO;
-import com.alkemy.ong.dto.OrganizationInfoResponse;
-import com.alkemy.ong.dto.ReducedOrganizationDTO;
-import com.alkemy.ong.dto.SlidesEntityDTO;
+import com.alkemy.ong.dto.*;
 import com.alkemy.ong.exception.CloudStorageClientException;
 import com.alkemy.ong.exception.CorruptedFileException;
 import com.alkemy.ong.services.OrganizationService;
@@ -13,8 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -44,11 +41,10 @@ public class OrganizationController {
     }
 
     @PostMapping
-    public ResponseEntity<?> updateOrganization(@RequestParam(value = "file", required = false) MultipartFile image,
-                                                              @ModelAttribute OrganizationDTO organizationDTO) throws CloudStorageClientException, CorruptedFileException {
+    public ResponseEntity<?> updateOrganization(@Valid @RequestBody OrganizationDTORequest organizationDTO) throws CloudStorageClientException, CorruptedFileException {
 
         try{
-            OrganizationDTO org = organizationService.updateOrganization(image, organizationDTO);
+            OrganizationDTO org = organizationService.updateOrganization(organizationDTO);
 
             return ResponseEntity.ok().body(org);
         }catch (RuntimeException e){

--- a/src/main/java/com/alkemy/ong/controllers/SlidesController.java
+++ b/src/main/java/com/alkemy/ong/controllers/SlidesController.java
@@ -3,6 +3,7 @@ package com.alkemy.ong.controllers;
 import com.alkemy.ong.dto.DeleteEntityResponse;
 import com.alkemy.ong.dto.ReducedSlideDTO;
 import com.alkemy.ong.dto.SlidesEntityDTO;
+import com.alkemy.ong.dto.SlidesEntityDTORequest;
 import com.alkemy.ong.exception.CloudStorageClientException;
 import com.alkemy.ong.exception.CorruptedFileException;
 import com.alkemy.ong.exception.FileNotFoundOnCloudException;
@@ -13,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
@@ -49,10 +49,9 @@ public class SlidesController {
     }
 
     @PostMapping
-    public ResponseEntity<?> createSlide(@RequestParam(value = "file",required = false)MultipartFile file, @ModelAttribute SlidesEntityDTO slidesDTO) throws IOException, CloudStorageClientException, CorruptedFileException {
+    public ResponseEntity<?> createSlide(@Valid @RequestBody SlidesEntityDTORequest slidesDTO) throws IOException, CloudStorageClientException, CorruptedFileException {
         try {
-            slidesDTO.setImageUrl(cloudStorageService.uploadBase64File(file));
-            return ResponseEntity.status(HttpStatus.CREATED).body(this.slidesService.create(file,slidesDTO));
+            return ResponseEntity.status(HttpStatus.CREATED).body(this.slidesService.create(slidesDTO));
         }catch (RuntimeException e){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
@@ -70,9 +69,9 @@ public class SlidesController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?>updateSlide(@RequestParam(value = "file", required = false) MultipartFile file, @Valid @ModelAttribute SlidesEntityDTO slide,@PathVariable String id) throws CloudStorageClientException, CorruptedFileException {
+    public ResponseEntity<?>updateSlide(@Valid @RequestBody SlidesEntityDTORequest slide,@PathVariable String id) throws CloudStorageClientException, CorruptedFileException {
         try {
-            return ResponseEntity.ok(this.slidesService.updateSlide(id,file,slide));
+            return ResponseEntity.ok(this.slidesService.updateSlide(id,slide));
         } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/alkemy/ong/controllers/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controllers/TestimonialController.java
@@ -43,9 +43,8 @@ public class TestimonialController {
             })
     })
     @PostMapping
-    public ResponseEntity<?> createTestimonial(@Valid @ModelAttribute TestimonialDTORequest request,
-                                               @RequestParam("file") MultipartFile file) throws CloudStorageClientException, CorruptedFileException {
-        return new ResponseEntity<>(service.create(file,request), HttpStatus.CREATED);
+    public ResponseEntity<?> createTestimonial(@Valid @RequestBody TestimonialDTORequest request) throws CloudStorageClientException, CorruptedFileException {
+        return new ResponseEntity<>(service.create(request), HttpStatus.CREATED);
     }
 
     @Operation(summary = "Update an existing testimonial", security = @SecurityRequirement(name = "bearerAuth"))
@@ -60,11 +59,10 @@ public class TestimonialController {
         }),
     })
     @PutMapping
-    public ResponseEntity<?> updateTestimonial(@Valid @ModelAttribute TestimonialDTORequest request,
-                                               @RequestParam(value = "file", required = false) MultipartFile file,
+    public ResponseEntity<?> updateTestimonial(@Valid @RequestBody TestimonialDTORequest request,
                                                @RequestParam("id")String id) throws CloudStorageClientException, CorruptedFileException {
        try{
-           return new ResponseEntity<>(service.update(id,file,request), HttpStatus.OK);
+           return new ResponseEntity<>(service.update(id,request), HttpStatus.OK);
        } catch (NotFoundException e) {
          return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
        }

--- a/src/main/java/com/alkemy/ong/controllers/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controllers/TestimonialController.java
@@ -6,12 +6,13 @@ import com.alkemy.ong.exception.CorruptedFileException;
 import com.alkemy.ong.exception.FileNotFoundOnCloudException;
 import com.alkemy.ong.services.TestimonialService;
 import com.alkemy.ong.utility.GlobalConstants;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import javassist.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 
@@ -22,22 +23,26 @@ public class TestimonialController {
     @Autowired
     private TestimonialService service;
 
+    @Operation(summary = "Crear un testimonial", security = @SecurityRequirement(name = "bearerAuth"))
     @PostMapping
-    public ResponseEntity<?> createTestimonial(@Valid @ModelAttribute TestimonialDTORequest request,
-                                               @RequestParam("file") MultipartFile file) throws CloudStorageClientException, CorruptedFileException {
-        return new ResponseEntity<>(service.create(file,request), HttpStatus.CREATED);
+    public ResponseEntity<?> createTestimonial(@Valid @RequestBody TestimonialDTORequest request) throws CloudStorageClientException, CorruptedFileException {
+
+        return new ResponseEntity<>(service.create(request), HttpStatus.CREATED);
+
     }
+
+    @Operation(summary = "Actualizar un testimonial", security = @SecurityRequirement(name = "bearerAuth"))
     @PutMapping
-    public ResponseEntity<?> updateTestimonial(@Valid @ModelAttribute TestimonialDTORequest request,
-                                               @RequestParam(value = "file", required = false) MultipartFile file,
+    public ResponseEntity<?> updateTestimonial(@Valid @RequestBody TestimonialDTORequest request,
                                                @RequestParam("id")String id) throws CloudStorageClientException, CorruptedFileException {
        try{
-           return new ResponseEntity<>(service.update(id,file,request), HttpStatus.OK);
+           return new ResponseEntity<>(service.update(id,request), HttpStatus.OK);
        } catch (NotFoundException e) {
          return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
        }
 
     }
+
     @DeleteMapping
     public ResponseEntity<?>deleteTestimonial(@RequestParam("id")String id)throws CloudStorageClientException, FileNotFoundOnCloudException {
 
@@ -47,4 +52,5 @@ public class TestimonialController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
     }
+
 }

--- a/src/main/java/com/alkemy/ong/controllers/UserController.java
+++ b/src/main/java/com/alkemy/ong/controllers/UserController.java
@@ -46,9 +46,9 @@ public class UserController {
 
 
  @PutMapping
-    public ResponseEntity<?> updateUser(@RequestParam(value = "file", required = false) MultipartFile multipartfile,@Valid @ModelAttribute UserDTORequest userDTORequest) throws CloudStorageClientException, CorruptedFileException {
+    public ResponseEntity<?> updateUser(@Valid @RequestBody UserDTORequest userDTORequest) throws CloudStorageClientException, CorruptedFileException {
         try {
-            return new ResponseEntity<>(userService.updateUser(multipartfile, userDTORequest), HttpStatus.OK);
+            return new ResponseEntity<>(userService.updateUser(userDTORequest), HttpStatus.OK);
         } catch (NotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }catch (Exception e){

--- a/src/main/java/com/alkemy/ong/dto/ActivityDTORequest.java
+++ b/src/main/java/com/alkemy/ong/dto/ActivityDTORequest.java
@@ -1,0 +1,16 @@
+package com.alkemy.ong.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivityDTORequest extends ActivityDTO {
+
+    private EncodedImageDTO encoded_image;
+
+}

--- a/src/main/java/com/alkemy/ong/dto/EncodedImageDTO.java
+++ b/src/main/java/com/alkemy/ong/dto/EncodedImageDTO.java
@@ -1,0 +1,21 @@
+package com.alkemy.ong.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EncodedImageDTO {
+
+    @NotBlank
+    private String encoded_string;
+    @NotBlank
+    private String file_name;
+
+}

--- a/src/main/java/com/alkemy/ong/dto/EncodedImageDTO.java
+++ b/src/main/java/com/alkemy/ong/dto/EncodedImageDTO.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,8 +15,10 @@ import javax.validation.constraints.NotBlank;
 public class EncodedImageDTO {
 
     @NotBlank
+    @Schema(description = "String representing the encoded image in base64. Will be quite long.", example = "/9j/4AAQSkZJRgABAQEAYABgA")
     private String encoded_string;
     @NotBlank
+    @Schema(description = "The file name with its extension.", example = "file_name.jpg")
     private String file_name;
 
 }

--- a/src/main/java/com/alkemy/ong/dto/MemberDTORequest.java
+++ b/src/main/java/com/alkemy/ong/dto/MemberDTORequest.java
@@ -25,4 +25,7 @@ public class MemberDTORequest {
     private String description;
 
     private String image;
+
+    private EncodedImageDTO encoded_image;
+
 }

--- a/src/main/java/com/alkemy/ong/dto/NewsDTORequest.java
+++ b/src/main/java/com/alkemy/ong/dto/NewsDTORequest.java
@@ -1,0 +1,16 @@
+package com.alkemy.ong.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class NewsDTORequest extends NewsDTO {
+
+    private EncodedImageDTO encoded_image;
+
+}

--- a/src/main/java/com/alkemy/ong/dto/OrganizationDTORequest.java
+++ b/src/main/java/com/alkemy/ong/dto/OrganizationDTORequest.java
@@ -1,0 +1,16 @@
+package com.alkemy.ong.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrganizationDTORequest extends OrganizationDTO {
+
+    private EncodedImageDTO encoded_image;
+
+}

--- a/src/main/java/com/alkemy/ong/dto/SlidesEntityDTORequest.java
+++ b/src/main/java/com/alkemy/ong/dto/SlidesEntityDTORequest.java
@@ -1,0 +1,16 @@
+package com.alkemy.ong.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SlidesEntityDTORequest extends SlidesEntityDTO {
+
+    private EncodedImageDTO encoded_image;
+
+}

--- a/src/main/java/com/alkemy/ong/dto/TestimonialDTORequest.java
+++ b/src/main/java/com/alkemy/ong/dto/TestimonialDTORequest.java
@@ -19,4 +19,6 @@ public class TestimonialDTORequest {
     @NotEmpty(message = "Content not provided")
     private String content;
 
+    private EncodedImageDTO encoded_image;
+
 }

--- a/src/main/java/com/alkemy/ong/dto/TestimonialDTORequest.java
+++ b/src/main/java/com/alkemy/ong/dto/TestimonialDTORequest.java
@@ -22,6 +22,7 @@ public class TestimonialDTORequest {
     @NotEmpty(message = "Content not provided")
     private String content;
 
+    @Schema(description = "Associated image encoded using base64")
     private EncodedImageDTO encoded_image;
 
 }

--- a/src/main/java/com/alkemy/ong/dto/UserDTORequest.java
+++ b/src/main/java/com/alkemy/ong/dto/UserDTORequest.java
@@ -21,6 +21,7 @@ public class UserDTORequest {
     private String email;
     @Size(min = 1, max = 255)
     private String password;
+    private EncodedImageDTO encoded_image;
 
 
 }

--- a/src/main/java/com/alkemy/ong/security/controller/AuthController.java
+++ b/src/main/java/com/alkemy/ong/security/controller/AuthController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import com.alkemy.ong.security.payload.SignupRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.multipart.MultipartFile;
 import javax.validation.Valid;
 import java.util.HashMap;
 
@@ -32,10 +31,9 @@ public class AuthController {
     private UserService userService;
 
     @PostMapping(GlobalConstants.Endpoints.REGISTER)
-    public ResponseEntity<?> register(@RequestParam(value="file", required = false) MultipartFile image,
-                                      @ModelAttribute @Valid SignupRequest signupRequest) {
+    public ResponseEntity<?> register(@RequestBody @Valid SignupRequest signupRequest) {
           try {
-              SingupResponse response = userService.createUser(signupRequest, image);
+              SingupResponse response = userService.createUser(signupRequest);
 
               return new ResponseEntity(response, HttpStatus.CREATED);
           } catch (RegisterException e){

--- a/src/main/java/com/alkemy/ong/security/payload/SignupRequest.java
+++ b/src/main/java/com/alkemy/ong/security/payload/SignupRequest.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.security.payload;
 
+import com.alkemy.ong.dto.EncodedImageDTO;
 import lombok.Getter;
 import lombok.Setter;
 import javax.validation.constraints.Email;
@@ -20,4 +21,6 @@ public class SignupRequest {
 
     @NotBlank(message = "Password cant be blank")
     private String password;
+
+    private EncodedImageDTO encoded_image;
 }

--- a/src/main/java/com/alkemy/ong/services/ActivitiesService.java
+++ b/src/main/java/com/alkemy/ong/services/ActivitiesService.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.services;
 
 import com.alkemy.ong.dto.ActivityDTO;
+import com.alkemy.ong.dto.ActivityDTORequest;
 import com.alkemy.ong.exception.ActivityNamePresentException;
 import com.alkemy.ong.exception.ActivityNotFoundException;
 import com.alkemy.ong.exception.CloudStorageClientException;
@@ -10,9 +11,11 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ActivitiesService {
 
     public ActivityDTO save (MultipartFile file, ActivityDTO dto) throws CloudStorageClientException, ActivityNamePresentException, CorruptedFileException;
+    public ActivityDTO save (ActivityDTORequest dto) throws CloudStorageClientException, ActivityNamePresentException, CorruptedFileException;
 
 
     public ActivityDTO edit (MultipartFile file, ActivityDTO dto, String id) throws CloudStorageClientException, ActivityNamePresentException, ActivityNotFoundException, CorruptedFileException;
+    public ActivityDTO edit (ActivityDTORequest dto, String id) throws CloudStorageClientException, ActivityNamePresentException, ActivityNotFoundException, CorruptedFileException;
 
 
 }

--- a/src/main/java/com/alkemy/ong/services/CloudStorageService.java
+++ b/src/main/java/com/alkemy/ong/services/CloudStorageService.java
@@ -53,4 +53,17 @@ public interface CloudStorageService {
      * @throws CloudStorageClientException if there was a problem with the Amazon S3 client.
      */
     String uploadBase64File(MultipartFile multipartFile) throws CorruptedFileException, CloudStorageClientException;
+
+    /**
+     * Uploads a file to the external Cloud Storage.
+     *
+     * The file should be encoded in Base64. It will then be decoded and uploaded to the cloud.
+     *
+     * @param encodedImage the encoded file in the resulting string format.
+     * @param fileName the original file name, extension included.
+     * @return  the absolute url to access the uploaded file.
+     * @throws CorruptedFileException if there was a problem with the received file.
+     * @throws CloudStorageClientException if there was a problem with the Amazon S3 client.
+     */
+    String uploadBase64File(String encodedImage, String fileName) throws CorruptedFileException, CloudStorageClientException;
 }

--- a/src/main/java/com/alkemy/ong/services/MemberService.java
+++ b/src/main/java/com/alkemy/ong/services/MemberService.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 public interface MemberService {
     MemberDTOResponse create(MultipartFile file,MemberDTORequest request) throws CloudStorageClientException, CorruptedFileException;
+    MemberDTOResponse create(MemberDTORequest request) throws CloudStorageClientException, CorruptedFileException;
     String deleteMember(String id) throws NotFoundException, CloudStorageClientException, FileNotFoundOnCloudException;
     List<MemberDTOResponse> getAllMembers();
 
@@ -28,6 +29,7 @@ public interface MemberService {
     PageResultResponse<MemberDTOResponse> getAllMembers(int pageNumber) throws PageIndexOutOfBoundsException;
 
     MemberDTOResponse edit(MultipartFile file, MemberDTORequest request, String id) throws MemberNotFoundException, Exception;
+    MemberDTOResponse edit(MemberDTORequest request, String id) throws MemberNotFoundException, Exception;
 
 }
 

--- a/src/main/java/com/alkemy/ong/services/NewsService.java
+++ b/src/main/java/com/alkemy/ong/services/NewsService.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.services;
 
 import com.alkemy.ong.dto.DatedNewsDTO;
 import com.alkemy.ong.dto.NewsDTO;
+import com.alkemy.ong.dto.NewsDTORequest;
 import com.alkemy.ong.dto.PageResultResponse;
 import com.alkemy.ong.exception.CloudStorageClientException;
 import com.alkemy.ong.exception.CorruptedFileException;
@@ -12,6 +13,7 @@ import javax.persistence.EntityNotFoundException;
 
 public interface NewsService {
   NewsDTO save (MultipartFile file, NewsDTO news) throws CloudStorageClientException, CorruptedFileException;
+  NewsDTO save (NewsDTORequest news) throws CloudStorageClientException, CorruptedFileException;
 
   NewsDTO findById(String id);
 
@@ -41,6 +43,20 @@ public interface NewsService {
    * @throws IllegalArgumentException if the News' Category to be updated is present but has an invalid name.
    */
   NewsDTO updateNews(String id, MultipartFile image, NewsDTO updatedNews) throws EntityNotFoundException, IllegalArgumentException, CloudStorageClientException, CorruptedFileException;
+
+  /**
+   * Updates a News entry.
+   *
+   * @param id  the id of the News to be edited.
+   * @param updatedNews the DTO with the updated fields of the News. The Entity whole Entity is updated from these values,
+   *                    so every field must be present, not just the updated ones, with the exception of the encoded file.
+   * @return  an dto with the info from the updated entity.
+   * @throws EntityNotFoundException  if an entity with the provided id can't be found.
+   * @throws CorruptedFileException  if there was a problem with the file attached.
+   * @throws CloudStorageClientException  if there was a problem with the cloud storage service.
+   * @throws IllegalArgumentException if the News' Category to be updated is present but has an invalid name.
+   */
+  NewsDTO updateNews(String id, NewsDTORequest updatedNews) throws EntityNotFoundException, IllegalArgumentException, CloudStorageClientException, CorruptedFileException;
 
   /**
    * Performs a paginated search for all the News entries in the database and returns them alongside the urls

--- a/src/main/java/com/alkemy/ong/services/OrganizationService.java
+++ b/src/main/java/com/alkemy/ong/services/OrganizationService.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.services;
 
 import com.alkemy.ong.dto.OrganizationDTO;
+import com.alkemy.ong.dto.OrganizationDTORequest;
 import com.alkemy.ong.dto.ReducedOrganizationDTO;
 import com.alkemy.ong.exception.CloudStorageClientException;
 import com.alkemy.ong.exception.CorruptedFileException;
@@ -22,4 +23,5 @@ public interface OrganizationService {
     public ReducedOrganizationDTO getById (String id) throws RuntimeException;
 
     public OrganizationDTO updateOrganization(MultipartFile image, OrganizationDTO organizationDTO) throws RuntimeException, CloudStorageClientException, CorruptedFileException;
+    public OrganizationDTO updateOrganization(OrganizationDTORequest organizationDTO) throws RuntimeException, CloudStorageClientException, CorruptedFileException;
 }

--- a/src/main/java/com/alkemy/ong/services/SlidesService.java
+++ b/src/main/java/com/alkemy/ong/services/SlidesService.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.services;
 
 import com.alkemy.ong.dto.ReducedSlideDTO;
 import com.alkemy.ong.dto.SlidesEntityDTO;
+import com.alkemy.ong.dto.SlidesEntityDTORequest;
 import com.alkemy.ong.entities.SlidesEntity;
 import com.alkemy.ong.exception.CloudStorageClientException;
 import com.alkemy.ong.exception.CorruptedFileException;
@@ -20,8 +21,10 @@ public interface SlidesService {
     List<ReducedSlideDTO> slideList();
 
     SlidesEntityDTO create(MultipartFile file,SlidesEntityDTO slide) throws CloudStorageClientException, CorruptedFileException;
+    SlidesEntityDTO create(SlidesEntityDTORequest slide) throws CloudStorageClientException, CorruptedFileException;
 
     SlidesEntityDTO deleteSlide(String id) throws EntityNotFoundException, CloudStorageClientException, FileNotFoundOnCloudException;
 
     SlidesEntityDTO updateSlide(String id,MultipartFile file,SlidesEntityDTO slide) throws EntityNotFoundException, IllegalArgumentException, CloudStorageClientException, CorruptedFileException;
+    SlidesEntityDTO updateSlide(String id,SlidesEntityDTORequest slide) throws EntityNotFoundException, IllegalArgumentException, CloudStorageClientException, CorruptedFileException;
 }

--- a/src/main/java/com/alkemy/ong/services/TestimonialService.java
+++ b/src/main/java/com/alkemy/ong/services/TestimonialService.java
@@ -10,6 +10,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface TestimonialService {
     TestimonialDTOResponse create(MultipartFile file, TestimonialDTORequest request)throws CloudStorageClientException, CorruptedFileException;
+    TestimonialDTOResponse create(TestimonialDTORequest request)throws CloudStorageClientException, CorruptedFileException;
     TestimonialDTOResponse update(String id,MultipartFile file, TestimonialDTORequest request) throws CloudStorageClientException, CorruptedFileException, NotFoundException;
+    TestimonialDTOResponse update(String id,TestimonialDTORequest request) throws CloudStorageClientException, CorruptedFileException, NotFoundException;
     String delete (String id) throws NotFoundException, CloudStorageClientException, FileNotFoundOnCloudException;
 }

--- a/src/main/java/com/alkemy/ong/services/UserService.java
+++ b/src/main/java/com/alkemy/ong/services/UserService.java
@@ -19,11 +19,13 @@ import java.util.Optional;
 public interface UserService {
 
   SingupResponse createUser(SignupRequest  signupRequest, MultipartFile image) throws IOException, CloudStorageClientException, CorruptedFileException;
+  SingupResponse createUser(SignupRequest  signupRequest) throws IOException, CloudStorageClientException, CorruptedFileException;
 
   public User save(User user);
   Optional<User> getUserByEmail(String email);
   String delete(String id) throws NotFoundException;
   UserDTO updateUser(MultipartFile file, UserDTORequest userDTOrequest) throws Exception;
+  UserDTO updateUser(UserDTORequest userDTOrequest) throws Exception;
   List<UserDTO> getAll();
   UserDTO getMe(String jwt) throws Exception;
 

--- a/src/main/java/com/alkemy/ong/services/impl/ActivitiesServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/ActivitiesServiceImpl.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.services.impl;
 
 import com.alkemy.ong.dto.ActivityDTO;
+import com.alkemy.ong.dto.ActivityDTORequest;
 import com.alkemy.ong.entities.ActivityEntity;
 import com.alkemy.ong.exception.ActivityNamePresentException;
 import com.alkemy.ong.exception.ActivityNotFoundException;
@@ -50,6 +51,29 @@ public class ActivitiesServiceImpl implements ActivitiesService {
         return dtoReturn;
     }
 
+    @Override
+    public ActivityDTO save(ActivityDTORequest dto) throws CloudStorageClientException, ActivityNamePresentException, CorruptedFileException {
+        Boolean entityFound = activityRepository.existsByName(dto.getName());
+        if (entityFound) {
+            throw new ActivityNamePresentException("Activity with the provided name is already present over the system");
+        }
+
+        if (dto.getEncoded_image() != null) {
+            dto.setImage(amazonS3Service.uploadBase64File(
+                    dto.getEncoded_image().getEncoded_string(),
+                    dto.getEncoded_image().getFile_name()
+            ));
+        } else {
+            dto.setImage(null);
+        }
+
+        ActivityEntity entity = activityMapper.activityDTO2Entity(dto);
+        ActivityEntity entitySaved = activityRepository.save(entity);
+
+        ActivityDTO dtoReturn = activityMapper.activityEntity2DTO(entitySaved);
+
+        return dtoReturn;
+    }
 
 
     public ActivityDTO edit(MultipartFile file, ActivityDTO dto, String id) throws CloudStorageClientException, ActivityNamePresentException, ActivityNotFoundException, CorruptedFileException {
@@ -67,6 +91,36 @@ public class ActivitiesServiceImpl implements ActivitiesService {
 
         if (file != null && !file.isEmpty()) {
             dto.setImage(amazonS3Service.uploadFile(file));
+        } else {
+            dto.setImage(null);
+        }
+
+        ActivityEntity modifiedEntity = activityMapper.editEntity(entityFound.get(), dto);
+        activityRepository.save(modifiedEntity);
+        ActivityDTO result = activityMapper.activityEntity2DTO(modifiedEntity);
+
+        return result;
+    }
+
+    @Override
+    public ActivityDTO edit(ActivityDTORequest dto, String id) throws CloudStorageClientException, ActivityNamePresentException, ActivityNotFoundException, CorruptedFileException {
+        Optional<ActivityEntity> entityFound = activityRepository.findById(id);
+
+        if (!entityFound.isPresent()) {
+            throw new ActivityNotFoundException("Activity with the provided ID was not found over the system");
+        }
+
+        Optional<ActivityEntity> entitySameName = activityRepository.findByName(dto.getName());
+
+        if (entitySameName.isPresent() && entitySameName.get().getId() != entityFound.get().getId()) {
+            throw new ActivityNamePresentException("Cannot change to the provided name as it should be unique over the system");
+        }
+
+        if (dto.getEncoded_image() != null) {
+            dto.setImage(amazonS3Service.uploadBase64File(
+                    dto.getEncoded_image().getEncoded_string(),
+                    dto.getEncoded_image().getFile_name()
+            ));
         } else {
             dto.setImage(null);
         }

--- a/src/main/java/com/alkemy/ong/services/impl/AmazonS3ServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/AmazonS3ServiceImpl.java
@@ -170,5 +170,33 @@ public class AmazonS3ServiceImpl implements CloudStorageService {
         return this.s3client.getUrl(bucketName, fileName).toString();
     }
 
+    /**
+     * Uploads a file to the Amazon S3 Bucket
+     *
+     * The file should be encoded in Base64. It will then be decoded and uploaded to the cloud.
+     *
+     * @param encodedImage the encoded file in the resulting string format.
+     * @param originalFileName the original file name, extension included.
+     * @return  the absolute url to access the uploaded file
+     * @throws CorruptedFileException if there was a problem with the received file.
+     * @throws CloudStorageClientException if there was a problem with the Amazon S3 client.
+     */
+    @Override
+    public String uploadBase64File(String encodedImage, String originalFileName) throws CorruptedFileException, CloudStorageClientException {
+
+        String fileName = FileManager.buildFileName(originalFileName).withTimeStamp().withoutSpaces().build();
+        File file = FileManager.convertBase64StringToFile(encodedImage, fileName);
+        String bucketName = this.credentialsConfiguration.getBucketName();
+        PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, fileName, file);
+        try {
+            s3client.putObject(putObjectRequest);
+        } catch (Exception e) {
+            throw new CloudStorageClientException(e.getMessage(), e);
+        } finally {
+            file.delete();
+        }
+        return this.s3client.getUrl(bucketName, fileName).toString();
+    }
+
 
 }

--- a/src/main/java/com/alkemy/ong/services/impl/TestimonialServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/TestimonialServiceImpl.java
@@ -41,12 +41,45 @@ public class TestimonialServiceImpl implements TestimonialService {
     }
 
     @Override
+    public TestimonialDTOResponse create(TestimonialDTORequest request) throws CloudStorageClientException, CorruptedFileException {
+
+        Testimonial testimonial= mapper.dtoRequest2TestimonialEntity(request);
+        if(request.getEncoded_image() != null){
+            testimonial.setImage(amazonS3Service.uploadBase64File(
+                    request.getEncoded_image().getEncoded_string(),
+                    request.getEncoded_image().getFile_name()
+            ));
+        }
+        repository.save(testimonial);
+        return mapper.testimonialEntity2DTOResponse(testimonial);
+
+    }
+
+    @Override
     public TestimonialDTOResponse update(String id, MultipartFile file, TestimonialDTORequest request) throws CloudStorageClientException, CorruptedFileException, NotFoundException {
         Boolean exists = repository.existsById(id);
         if (!exists)throw new NotFoundException("Error: Testimonial with id " + id + " was not found");
         Testimonial testimonialFound= repository.getById(id);
         if(file != null && !file.isEmpty()){
             testimonialFound.setImage(amazonS3Service.uploadFile(file));
+        }
+        if(!request.getName().isEmpty()) testimonialFound.setName(request.getName());
+        if(!request.getContent().isEmpty()) testimonialFound.setContent(request.getContent());
+
+        repository.save(testimonialFound);
+        return mapper.testimonialEntity2DTOResponse(testimonialFound);
+    }
+
+    @Override
+    public TestimonialDTOResponse update(String id, TestimonialDTORequest request) throws CloudStorageClientException, CorruptedFileException, NotFoundException {
+        Boolean exists = repository.existsById(id);
+        if (!exists)throw new NotFoundException("Error: Testimonial with id " + id + " was not found");
+        Testimonial testimonialFound= repository.getById(id);
+        if(request.getEncoded_image() != null){
+            testimonialFound.setImage(amazonS3Service.uploadBase64File(
+                    request.getEncoded_image().getEncoded_string(),
+                    request.getEncoded_image().getFile_name()
+            ));
         }
         if(!request.getName().isEmpty()) testimonialFound.setName(request.getName());
         if(!request.getContent().isEmpty()) testimonialFound.setContent(request.getContent());

--- a/src/main/java/com/alkemy/ong/utility/FileManager.java
+++ b/src/main/java/com/alkemy/ong/utility/FileManager.java
@@ -27,6 +27,16 @@ public abstract class FileManager {
     }
 
     /**
+     * Generates a file name with extra options provided using a builder.
+     *
+     * @param fileName the file name.
+     * @return  a gemerated name for the file.
+     */
+    public static FileNameBuilder buildFileName(String fileName) {
+        return new FileNameBuilder( fileName );
+    }
+
+    /**
      * Converts a multi-part file into an in-memory java io File.
      * @param multipartFile the multi-part file, received from an endpoint.
      * @return  an in-memory Java file.
@@ -107,6 +117,27 @@ public abstract class FileManager {
             File simpleFile = new File(multipartFile.getOriginalFilename());
             FileOutputStream fileOutputStream = new FileOutputStream(simpleFile);
             fileOutputStream.write(Base64.getDecoder().decode( multipartFile.getBytes() ));
+            fileOutputStream.close();
+            return simpleFile;
+        } catch (IOException e) {
+            throw new CorruptedFileException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Converts a base64 encoded multi-part file into an in-memory decoded java io File.
+     *
+     * @param encodedFile the encoded file in the resulting string format.
+     * @param fileName the original file name, extension included.
+     * @return  an in-memory Java file, decoded.
+     * @throws CorruptedFileException  if the original file name can't be retrieved from the multi-part file, or if
+     * the latter is corrupted.
+     */
+    public static File convertBase64StringToFile(String encodedFile, String fileName) throws CorruptedFileException {
+        try {
+            File simpleFile = new File(fileName);
+            FileOutputStream fileOutputStream = new FileOutputStream(simpleFile);
+            fileOutputStream.write(Base64.getDecoder().decode(encodedFile));
             fileOutputStream.close();
             return simpleFile;
         } catch (IOException e) {


### PR DESCRIPTION
El cambio principal es este: en vez de recibir un MultipartFile y un DTO en un endpoint cuando tenemos que hacer un request de create o update, se recibe solamente el DTO, el cual ahora tiene adentro un atributo con la imagen encodeada.

[Recomiendo esta página para encodear imagenes a base64 y hacer pruebas](https://codebeautify.org/image-to-base64-converter). Suben la imagen, les genera el string, lo copian y listo, después lo pegan en el campo correspondiente de la request.
Las request entonces ahora se pueden hacer pasando un JSON.

#### Resumen de los cambios puntuales que se hicieron en el código para implementar esto:

- Se sobrecargaron los métodos de create y update de los services que usaban multipart, es decir, se copiaron y pegaron abajo, con la nueva versión que no necesita el multipart sino el DTO con la imagen encodeada adentro, no se tocó nada más que esa adaptación (que implicó cambiar las 2 lineas q usaban el file nomas), y los métodos viejos siguen estando (por ej el Runner los usa y sigue 10 puntos).
- Para meter el atributo de imagen adentro de los DTO, cuando había una DTO que solamente se usaba como request, se le agregó ese atributo adentro y nada más (ni siquiera era necesario modificar los mappers). Cuando había DTOs que tb se usaban como respuesta, se extendieron a una clase hija que contiene el nuevo atributo y se usó esa en los métodos sobrecargados; como hay herencia, tampoco fue necesario modificar los mappers.
- En los controllers donde se recibían peticiones de create y update con MultipartFile, se borró el param del file, se dejó el DTO con el file encodeado adentro, se cambió la etiqueta @ModelAttribute por @RequestBody y se cambió el método viejo por el nuevo que usaba en los services (q como tienen el mismo nombre solamente consistió en borrarle el param file).

Anexo: [video mostrando la ejecución de consultas usando Swagger en vez de postman](https://youtu.be/-CjRdWlINxM)