### PR TITLE
Added id to TestimonialDTOResponse

### DIFF
--- a/src/main/java/com/alkemy/ong/dto/TestimonialDTOResponse.java
+++ b/src/main/java/com/alkemy/ong/dto/TestimonialDTOResponse.java
@@ -12,6 +12,8 @@ import lombok.Setter;
 @NoArgsConstructor
 public class TestimonialDTOResponse {
 
+    @Schema(description = "Entity id", example = "3b6f64ed-ecaa-4ae1-9e97-091464bc8dc1")
+    private String id;
     @Schema(description = "The name/title of the testimonial", example = "Testimonial from Juan, Director of the local high school.")
     private String name;
     @Schema(description = "Image that accompanies the testimonial", example = "com.image.jpg")

--- a/src/main/java/com/alkemy/ong/mappers/TestimonialMapper.java
+++ b/src/main/java/com/alkemy/ong/mappers/TestimonialMapper.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
         }
         public TestimonialDTOResponse testimonialEntity2DTOResponse(Testimonial testimonial){
             TestimonialDTOResponse response = new TestimonialDTOResponse();
+            response.setId(testimonial.getId());
             response.setName(testimonial.getName());
             response.setImage(testimonial.getImage());
             response.setContent(testimonial.getContent());


### PR DESCRIPTION
En el endpoint de testimonials, el endpoint getAll es el único método GET, sin embargo no devolvía el atributo id, por lo que el administrador no tenía forma de acceder a este dato para poder usar los otros endpoints de PUT y DELETE.

Como el ticket de Jira no especifica los campos que tiene que devolver este endpoint, para que no haya que estar ingresando manualmente a la base de datos para obtener estos valores, y ya que los otros endpoints están restringidos a administradores solamente, se agrega el atributo id al dto de respuesta del GET de Testimonial.